### PR TITLE
Increase max number of lines for Dynamic Tables to 300

### DIFF
--- a/src/utils/validation/validation-rules.js
+++ b/src/utils/validation/validation-rules.js
@@ -96,11 +96,11 @@ export const questionRules = {
   [`${RESPONSE_FORMAT}.${TABLE}.${PRIMARY}.totalLabel`]: [required],
   [`${RESPONSE_FORMAT}.${TABLE}.${PRIMARY}.${LIST}.numLinesMin`]: [
     value => minValue(1)(value),
-    value => maxValue(100)(value),
+    value => maxValue(300)(value),
   ],
   [`${RESPONSE_FORMAT}.${TABLE}.${PRIMARY}.${LIST}.numLinesMax`]: [
     value => minValue(1)(value),
-    value => maxValue(100)(value),
+    value => maxValue(300)(value),
   ],
   [`${RESPONSE_FORMAT}.${TABLE}.${PRIMARY}.${CODES_LIST}.${DEFAULT_CODES_LIST_SELECTOR_PATH}`]: [
     validCodesList,


### PR DESCRIPTION
Ticket 302 - Modifier le maximum de lignes pour les tableaux dynamiques (<=300)

This changes the maximum number of lines(numLinesMax) in Dynamic Tables from 100 to 300. Also adjusts the maximum value that numLinesMin can have to this change (from 100 to 300).