### PR TITLE
Manage NoDataByDefinition

### DIFF
--- a/src/constants/dictionary.js
+++ b/src/constants/dictionary.js
@@ -304,6 +304,10 @@ const dictionary = {
     en: 'Pattern',
     fr: 'Motif',
   },
+  collected: {
+    en: 'Collected',
+    fr: 'Collectée',
+  },
   disjoignable: {
     en: 'Detachable statement',
     fr: 'Déclaration détachable',

--- a/src/model/transformations/component.js
+++ b/src/model/transformations/component.js
@@ -23,16 +23,19 @@ function sortByWeight(store) {
     return 0;
   };
 }
-function getResponseCoordinate(variablesMapping = []) {
+function getResponseCoordinate(variablesMapping = [], variablesAttribute) {
   return variablesMapping.reduce((acc, m) => {
     const axis = m.MappingTarget.split(' ');
-    return {
+    const find = variablesAttribute ? variablesAttribute.find(ele => ele.AttributeTarget ===  m.MappingTarget) : false;
+    const variableRes =  {
       ...acc,
       [m.MappingSource]: {
         x: parseInt(axis[0], 10),
         y: parseInt(axis[1], 10),
       },
     };
+    find ? variableRes[m.MappingSource].isCollected = false : variableRes[m.MappingSource].isCollected = true;
+    return variableRes;
   }, {});
 }
 
@@ -155,8 +158,13 @@ function remoteToVariableResponseNested(children = [], acc = {}) {
     const variableResponseMapping = responseStructure
       ? responseStructure.Mapping
       : undefined;
+
+    const variableResponseAttribute = responseStructure
+    ? responseStructure.Attribute
+    : undefined;
+
     const coordinatesByResponse = getResponseCoordinate(
-      variableResponseMapping,
+      variableResponseMapping, variableResponseAttribute
     );
 
     acc = {

--- a/src/model/transformations/response-format-table.js
+++ b/src/model/transformations/response-format-table.js
@@ -386,6 +386,7 @@ export function stateToRemote(
     : listMeasuresState.length;
   let responsesModel = [];
   let mappingsModel = [];
+  let attributesModel = [];
 
   for (let i = 0; i < numDataTypes; i += 1) {
     const collectedVariablesByDatatype = collectedVariables
@@ -403,6 +404,7 @@ export function stateToRemote(
 
     responsesModel = [...responsesModel, ...responsesModelByRow.Response];
     mappingsModel = [...mappingsModel, ...responsesModelByRow.Mapping];
+    attributesModel = [...attributesModel, ...responsesModelByRow.Attribute];
   }
 
   mappingsModel = mappingsModel.sort((m1, m2) => {
@@ -419,5 +421,6 @@ export function stateToRemote(
     Dimension: dimensionsModel,
     Response: responsesModel,
     Mapping: mappingsModel,
+    Attribute: attributesModel,
   };
 }

--- a/src/model/transformations/response-format-table.spec.js
+++ b/src/model/transformations/response-format-table.spec.js
@@ -428,6 +428,7 @@ describe('stateToRemote', () => {
         DURATION: { maximum: '', minimum: '', format: '' },
         DATE: { maximum: '', minimum: '', format: '' },
         BOOLEAN: {},
+        isCollected: false,
         codeListReference: '',
         codeListReferenceLabel: '',
       },
@@ -443,6 +444,7 @@ describe('stateToRemote', () => {
         DURATION: { maximum: '', minimum: '', format: '' },
         DATE: { maximum: '', minimum: '', format: '' },
         BOOLEAN: {},
+        isCollected: false,
         codeListReference: '',
         codeListReferenceLabel: '',
       },
@@ -464,6 +466,17 @@ describe('stateToRemote', () => {
         dynamic: '0',
       },
     ]);
+
+    expect(result.Attribute).toEqual([
+      {
+        AttributeValue: 'NoDataByDefinition',
+        AttributeTarget: '1 1',
+      },
+      {
+        AttributeValue: 'NoDataByDefinition',
+        AttributeTarget: '2 1',
+      },
+    ])
 
     const outputMapping = result.Mapping;
     const outputResponse = result.Response;
@@ -519,6 +532,7 @@ describe('stateToRemote', () => {
         DURATION: { maximum: '', minimum: '', format: '' },
         DATE: {},
         BOOLEAN: {},
+        isCollected: false,
         codeListReference: '',
         codeListReferenceLabel: '',
       },
@@ -537,6 +551,13 @@ describe('stateToRemote', () => {
         dynamic: '0',
       },
       { Label: 'fsdfsdfsdf', dimensionType: 'MEASURE', dynamic: '0' },
+    ]);
+
+    expect(result.Attribute).toEqual([
+      { 
+        AttributeValue: 'NoDataByDefinition',
+        AttributeTarget: '1 1'
+      }
     ]);
 
     const outputMapping = result.Mapping;

--- a/src/model/transformations/response-format.js
+++ b/src/model/transformations/response-format.js
@@ -76,6 +76,7 @@ export function stateToRemote(
       ResponseStructure: {
         Dimension: dataTypeRemote.Dimension,
         Mapping: dataTypeRemote.Mapping,
+        Attribute: dataTypeRemote.Attribute,
       },
       Response: dataTypeRemote.Response,
     };

--- a/src/model/transformations/response-format.spec.js
+++ b/src/model/transformations/response-format.spec.js
@@ -107,6 +107,7 @@ describe('response transformation', () => {
         ResponseStructure: {
           Dimension: 'Dimension',
           Mapping: 'Mapping',
+          Attribute: 'Attribute',
         },
         Response: 'true',
       },
@@ -127,7 +128,7 @@ describe('response transformation', () => {
     };
 
     [SIMPLE, SINGLE_CHOICE, MULTIPLE_CHOICE, TABLE].forEach(type => {
-      it(`should call the ${type} stateRToRemote`, () => {
+      it(`should call the ${type} stateToRemote`, () => {
         let mockFn;
         switch (type) {
           case SINGLE_CHOICE:
@@ -146,6 +147,7 @@ describe('response transformation', () => {
           Response: 'true',
           Dimension: 'Dimension',
           Mapping: 'Mapping',
+          Attribute: 'Attribute',
         });
         const result = stateToRemote(
           {

--- a/src/model/transformations/responses.js
+++ b/src/model/transformations/responses.js
@@ -8,8 +8,8 @@ export function stateToModel(
   type,
 ) {
   let collectedVariablesFinal = collectedVariables;
-  if(type == 'MULTIPLE_CHOICE' || type == 'TABLE') {
-    collectedVariablesFinal.map(collected=> {
+  if(type === QUESTION_TYPE_ENUM.MULTIPLE_CHOICE || type === QUESTION_TYPE_ENUM.TABLE) {
+    collectedVariablesFinal.map(collected => {
       const find = Object.values(collectedVariablesStore).find(variable=> variable.id == collected);
       if(find && find.type == 'TEXT' && !find.x) {
         collectedVariablesFinal = collectedVariablesFinal.filter(element => element != find.id)
@@ -28,7 +28,7 @@ export function stateToModel(
     const MappingTarget =
       type === QUESTION_TYPE_ENUM.MULTIPLE_CHOICE ? `${x}` : `${x} ${y}`;
     
-      if (isCollected === false ) {
+      if (!isCollected) {
         attributeModel.push({
           "AttributeValue": "NoDataByDefinition",
           "AttributeTarget": MappingTarget
@@ -37,7 +37,7 @@ export function stateToModel(
     return { MappingSource: r.id, MappingTarget };
   });
 
-  if (type == 'TABLE') {
+  if (type === QUESTION_TYPE_ENUM.TABLE) {
     return {
       Response: responsesModel,
       Mapping: mappingModel,

--- a/src/model/transformations/responses.js
+++ b/src/model/transformations/responses.js
@@ -19,17 +19,34 @@ export function stateToModel(
   const responsesModel = collectedVariablesFinal.map(cv =>
     Response.stateToRemote({ ...state, collectedVariable: cv }),
   );
-  const mappingModel = responsesModel.map(r => {
-    const { x, y } = collectedVariablesStore[r.CollectedVariableReference];
 
+  let attributeModel = [];
+
+  const mappingModel = responsesModel.map(r => {
+    const { x, y, isCollected } = collectedVariablesStore[r.CollectedVariableReference];
     // Table : Fix lines and look into columns
     const MappingTarget =
       type === QUESTION_TYPE_ENUM.MULTIPLE_CHOICE ? `${x}` : `${x} ${y}`;
+    
+      if (isCollected === false ) {
+        attributeModel.push({
+          "AttributeValue": "NoDataByDefinition",
+          "AttributeTarget": MappingTarget
+        },)
+      }
     return { MappingSource: r.id, MappingTarget };
   });
 
-  return {
-    Response: responsesModel,
-    Mapping: mappingModel,
+  if (type == 'TABLE') {
+    return {
+      Response: responsesModel,
+      Mapping: mappingModel,
+      Attribute: attributeModel,
+    } 
+  } else {
+    return {
+      Response: responsesModel,
+      Mapping: mappingModel,
+    } 
   };
 }

--- a/src/utils/variables/collected-variables-utils.js
+++ b/src/utils/variables/collected-variables-utils.js
@@ -288,7 +288,11 @@ export function getCollectedVariablesTable(questionName, form, codesListStore) {
             getCollecteVariable(
               `${questionName}${i + 1}${j + 1}`,
               `${codePrimary.label}-${codeSecondary.label}-${measureState.label}`,
-              { x: i + 1, y: j + 1 },
+              {
+                x: i + 1,
+                y: j + 1,
+                isCollected: true
+              },
               getReponsesValues(measureState),
             ),
           );
@@ -310,6 +314,7 @@ export function getCollectedVariablesTable(questionName, form, codesListStore) {
               {
                 x: i + 1,
                 y: j + 1,
+                isCollected: true
               },
               getReponsesValues(measure),
             ),
@@ -325,7 +330,11 @@ export function getCollectedVariablesTable(questionName, form, codesListStore) {
         getCollecteVariable(
           `${questionName}${j + 1}`,
           `${measure.label}`,
-          { x: 1, y: j + 1 },
+          { 
+            x: 1,
+            y: j + 1,
+            isCollected: true
+          },
           getReponsesValues(measure),
         ),
       );
@@ -344,7 +353,8 @@ export function getCollectedVariablesTable(questionName, form, codesListStore) {
                     `${variable.name}${code.value}CL label`,
                     {
                       z: code.weight,
-                      mesureLevel: variable.x 
+                      mesureLevel: variable.x, 
+                      isCollected: true
                      },
                     {
                       type: "TEXT",

--- a/src/utils/variables/collected-variables-utils.spec.js
+++ b/src/utils/variables/collected-variables-utils.spec.js
@@ -537,14 +537,15 @@ describe('collected variables utils: ', () => {
   });
 
   describe('getCollecteVariable', () => {
-    test('should return the collected variablem with coordinates', () => {
-      const result = getCollecteVariable('name', 'label', { x: 1, y: 2 });
+    test('should return the collected variable with coordinates', () => {
+      const result = getCollecteVariable('name', 'label', { x: 1, y: 2, isCollected: false});
       expect(result).toEqual({
         id: result.id,
         name: 'name',
         label: 'label',
         x: 1,
         y: 2,
+        isCollected: false,
       });
     });
 
@@ -552,13 +553,13 @@ describe('collected variables utils: ', () => {
       const result = getCollecteVariable(
         'name',
         'label',
-        { x: 1, y: 2 },
+        { x: 1, y: 2,  isCollected: true},
         { id: 1 },
       );
       expect(result.id).not.toEqual(1);
     });
 
-    test('should return the collected variablem without coordinates', () => {
+    test('should return the collected variable without coordinates', () => {
       const result = getCollecteVariable('name', 'label');
       expect(result).toEqual({
         id: result.id,

--- a/src/widgets/component-new-edit/components/variables/collected-variables.jsx
+++ b/src/widgets/component-new-edit/components/variables/collected-variables.jsx
@@ -3,7 +3,7 @@ import { Field, FormSection } from 'redux-form';
 import PropTypes from 'prop-types';
 
 import { defaultState } from '../../model/collected-variable';
-import { DATATYPE_NAME } from 'constants/pogues-constants';
+import { DATATYPE_NAME, QUESTION_TYPE_ENUM } from 'constants/pogues-constants';
 
 import Input from 'forms/controls/input';
 import { ListWithInputPanel } from 'widgets/list-with-input-panel';
@@ -19,6 +19,8 @@ import ResponseFormatDatatypeDate from 'widgets/component-new-edit/components/re
 
 
 const { DATE, NUMERIC, TEXT, BOOLEAN, DURATION } = DATATYPE_NAME;
+const { TABLE } = QUESTION_TYPE_ENUM;
+
 // Utils
 
 const validateForm = (addErrors, validate) => (values, state) => {
@@ -99,7 +101,7 @@ class CollectedVariables extends Component {
       componentName,
       responseFormatType,
     } = this.props;
-    const hiddenCollected = responseFormatType !== "TABLE";
+    const hiddenCollected = responseFormatType !== TABLE;
 
     return (
       <FormSection name={selectorPath}>

--- a/src/widgets/component-new-edit/components/variables/collected-variables.jsx
+++ b/src/widgets/component-new-edit/components/variables/collected-variables.jsx
@@ -99,6 +99,8 @@ class CollectedVariables extends Component {
       componentName,
       responseFormatType,
     } = this.props;
+    const hiddenCollected = responseFormatType !== "TABLE";
+
     return (
       <FormSection name={selectorPath}>
         <ListWithInputPanel
@@ -151,14 +153,14 @@ class CollectedVariables extends Component {
               <ResponseFormatDatatypeText readOnly required={false} />
             </View>
             <View key={DATE} value={DATE} label={Dictionary.DATE} >
-            <ResponseFormatDatatypeDate readOnly required={false}/>
+              <ResponseFormatDatatypeDate readOnly required={false} />
             </View>
             <View key={NUMERIC} value={NUMERIC} label={Dictionary.NUMERIC}>
               <ResponseFormatDatatypeNumeric readOnly required={false} />
             </View>
             <View key={BOOLEAN} value={BOOLEAN} label={Dictionary.BOOLEAN} />
             <View key={DURATION} value={DURATION} label={Dictionary.DURATION} >
-            <ResponseFormatDatatypeDuree readOnly  required={false}/>
+              <ResponseFormatDatatypeDuree readOnly required={false} />
             </View>
           </SelectorView>
 
@@ -170,6 +172,17 @@ class CollectedVariables extends Component {
             component={Input}
             label={Dictionary.cl}
           />
+          <div className="ctrl-checkbox" hidden={hiddenCollected}>
+            <label htmlFor="collected-variables-isCollected">{Dictionary.collected}</label>
+            <div>
+              <Field
+                name="isCollected"
+                id="collected-variables-isCollected"
+                component="input"
+                type="checkbox"
+              />
+            </div> 
+          </div>
         </ListWithInputPanel>
       </FormSection>
     );

--- a/src/widgets/component-new-edit/model/collected-variable.js
+++ b/src/widgets/component-new-edit/model/collected-variable.js
@@ -13,6 +13,7 @@ export const defaultState = {
   mesureLevel:'',
   codeListReference: '',
   codeListReferenceLabel: '',
+  isCollected: true,
 };
 
 export const defaultForm = {
@@ -26,6 +27,7 @@ export const defaultForm = {
   collectedVariables: [],
   codeListReference: '',
   codeListReferenceLabel: '',
+  isCollected: true,
 };
 
 function getTypings(object) {
@@ -39,7 +41,7 @@ function getTypings(object) {
   };
 }
 export function formToState(form) {
-  const { name, label, x, y, z, mesureLevel, codeListReference, codeListReferenceLabel } = form;
+  const { name, label, x, y, z, mesureLevel, codeListReference, codeListReferenceLabel, isCollected } = form;
   const id = form.id || uuid();
   
   return {
@@ -49,6 +51,7 @@ export function formToState(form) {
     x,
     y,
     z,
+    isCollected,
     mesureLevel,
     ...getTypings(form),
     codeListReference,
@@ -80,6 +83,7 @@ export function storeToForm(currentStore) {
         x,
         y,
         z,
+        isCollected,
         mesureLevel,
         codeListReference,
         codeListReferenceLabel,
@@ -91,6 +95,7 @@ export function storeToForm(currentStore) {
         x,
         y,
         z,
+        isCollected,
         mesureLevel,
         ...getTypings(currentStore[key]),
         codeListReference,


### PR DESCRIPTION
Ticket 312B - Gestion des NoDataByDefinition

This adds the checkbox `Collected` in the tab 'Collected Variables' in responses of type `Table`.
This checkbox is checked by default. When unchecked by the user, an object, with keys `AttributeValue` and `AttributeTarget` relating to that variable, is added to `Attribute` in the JSON.
Also fixes some typos in the existing code.