### PR TITLE
Add tooltips to Measure Label Input

### DIFF
--- a/src/forms/controls/control-with-suggestions/components/rich-textarea-with-suggestions.jsx
+++ b/src/forms/controls/control-with-suggestions/components/rich-textarea-with-suggestions.jsx
@@ -36,9 +36,11 @@ function myKeyBindingFn(e) {
 
 const propTypes = {
   submitOnEnter: PropTypes.bool,
+  toolbar: PropTypes.object,
 };
 const defaultProps = {
   submitOnEnter: false,
+  toolbar: toolbarConfig,
 };
 
 // Control
@@ -185,6 +187,7 @@ class RichTextareaWithSuggestions extends ControlWithSuggestion {
       required,
       disabled,
       input,
+      toolbar,
       meta: { touched, error },
       targetIsQuestion,
     } = this.props;
@@ -202,7 +205,7 @@ class RichTextareaWithSuggestions extends ControlWithSuggestion {
             value={editorValue}
             onChange={this.handleChange}
             toolbarConfig={
-              targetIsQuestion ? toolbarConfigQuestion : toolbarConfig
+              targetIsQuestion ? toolbarConfigQuestion : toolbar
             }
             handleReturn={this.handleReturn}
             rootStyle={rootStyle}

--- a/src/forms/controls/rich-textarea/index.js
+++ b/src/forms/controls/rich-textarea/index.js
@@ -9,5 +9,6 @@ export {
 export {
   toolbarConfig,
   toolbarConfigQuestion,
+  toolbarConfigTooltip,
   rootStyle,
 } from './rich-textarea-toobar-config';

--- a/src/forms/controls/rich-textarea/rich-textarea-toobar-config.js
+++ b/src/forms/controls/rich-textarea/rich-textarea-toobar-config.js
@@ -35,6 +35,21 @@ export const toolbarConfigQuestion = {
   },
 };
 
+export const toolbarConfigTooltip = {
+  display: ['LINK_BUTTONS'],
+  extraProps: {
+    tabIndex: '-1',
+  },
+  LINK_BUTTONS: {
+    ADD: {
+      label: 'Link or Tooltip',
+      iconName: 'link',
+      placeholder: 'Insert an URL or a tooltip',
+    },
+    REMOVE: { label: 'Remove Link or Tooltip', iconName: 'remove-link' },
+  },
+};
+
 export const rootStyle = {
   display: 'flex',
   flexDirection: 'column-reverse',

--- a/src/forms/controls/rich-textarea/rich-textarea.jsx
+++ b/src/forms/controls/rich-textarea/rich-textarea.jsx
@@ -36,6 +36,7 @@ const propTypes = {
   input: PropTypes.shape(fieldInputPropTypes).isRequired,
   meta: PropTypes.shape(fieldMetaPropTypes).isRequired,
   label: PropTypes.string.isRequired,
+  toolbar: PropTypes.object,
   className: PropTypes.string,
   required: PropTypes.bool,
   focusOnInit: PropTypes.bool,
@@ -51,6 +52,7 @@ const defaultProps = {
   focusOnInit: false,
   showAddConditions: false,
   onEnter: undefined,
+  toolbar: toolbarConfig,
 };
 
 // Control
@@ -148,6 +150,7 @@ class RichTextarea extends Component {
       required,
       focusOnInit,
       showAddConditions,
+      toolbar,
       input,
       meta: { touched, error },
     } = this.props;
@@ -158,7 +161,7 @@ class RichTextarea extends Component {
       placeholder: label,
       value: this.state.editorValue,
       onChange: this.handleChange,
-      toolbarConfig: toolbarConfig,
+      toolbarConfig: toolbar,
       autoFocus: focusOnInit,
       keyBindingFn: this.keyBinding,
       rootStyle,

--- a/src/widgets/component-new-edit/components/response-format/table/input-measure.jsx
+++ b/src/widgets/component-new-edit/components/response-format/table/input-measure.jsx
@@ -3,7 +3,7 @@ import { Field } from 'redux-form';
 import PropTypes from 'prop-types';
 
 import { RichTextareaWithVariableAutoCompletion } from 'forms/controls/control-with-suggestions';
-import {toolbarConfigTooltip} from "forms/controls/rich-textarea";
+import {toolbarConfigTooltip} from 'forms/controls/rich-textarea';
 import { SelectorView, View } from 'widgets/selector-view';
 import ResponseFormatSimple from '../simple/response-format-simple';
 import ResponseFormatSingle from '../single/response-format-single';

--- a/src/widgets/component-new-edit/components/response-format/table/input-measure.jsx
+++ b/src/widgets/component-new-edit/components/response-format/table/input-measure.jsx
@@ -2,7 +2,8 @@ import React from 'react';
 import { Field } from 'redux-form';
 import PropTypes from 'prop-types';
 
-import { InputWithVariableAutoCompletion } from 'forms/controls/control-with-suggestions';
+import { RichTextareaWithVariableAutoCompletion } from 'forms/controls/control-with-suggestions';
+import {toolbarConfigTooltip} from "forms/controls/rich-textarea";
 import { SelectorView, View } from 'widgets/selector-view';
 import ResponseFormatSimple from '../simple/response-format-simple';
 import ResponseFormatSingle from '../single/response-format-single';
@@ -16,12 +17,12 @@ function InputMeasure(props) {
     <div>
       <Field
         name="label"
-        type="text"
-        component={InputWithVariableAutoCompletion}
+        component={RichTextareaWithVariableAutoCompletion}
         label={Dictionary.measureLabel}
+        toolbar={toolbarConfigTooltip}
         required
       />
-
+      
       <SelectorView
         label={Dictionary.typeMeasure}
         selectorPath={props.selectorPath}


### PR DESCRIPTION
306-FO-associer ou supprimer des info-bulles à des libellés de colonne de tableaux

This changes the input `Measure Label` in answers of type `Table` to `RichTextareaWithVariableAutoCompletion`, and uses the new `toolbarConfigTooltip` that displays only the tooltips.
The toolbar is passed as prop. If no toolbar prop is passed, it uses the default `toolbarConfig`.
