### PR TITLE
[FIX] Prevent Text Deletion While Referencing Variables

### DIFF
--- a/src/forms/controls/control-with-suggestions/components/utils.js
+++ b/src/forms/controls/control-with-suggestions/components/utils.js
@@ -1,4 +1,5 @@
 export function getPattern(value, caretPosition, substrToTheEnd = false) {
+
   let start = -1;
   let i = caretPosition;
   while (i >= 0 && start < 0) {
@@ -41,9 +42,9 @@ export function getValueWithSuggestion(suggestion, caretCursor, fullText) {
   
   const prefix = fullText.substr(0, start);
   const suffix = '';
-  const prefixSeparator = prefix && '$';
+  const prefixSeparator = '$';
   const suffixSeparator = suffix ? '$ ' : '$';
-  
+
   return [
     ...prefix,
     prefixSeparator,

--- a/src/forms/controls/control-with-suggestions/components/utils.spec.js
+++ b/src/forms/controls/control-with-suggestions/components/utils.spec.js
@@ -43,4 +43,22 @@ describe('getValueWithSuggestion', () => {
       'voici un $suggestion$',
     );
   });
+
+  test('if there is text before $, it should not be removed', () => {
+    const suggestion = 'suggestion';
+    const caretPosition = 11;
+    const fullText = 'here $sug';
+    expect(getValueWithSuggestion(suggestion, caretPosition, fullText)).toBe(
+      'here $suggestion$',
+    );
+  });
+
+  test('if there is no prefix, the first $ should not be removed and if there is no sufix, the second $ should not be removed', () => {
+    const suggestion = 'suggestion';
+    const caretPosition = 11;
+    const fullText = '$sug';
+    expect(getValueWithSuggestion(suggestion, caretPosition, fullText)).toBe(
+      '$suggestion$',
+    );
+  });
 });


### PR DESCRIPTION
This fixes an issue in 282bis - Suppression de texte quand on utilise le référencement des variables dans un message de contrôle.