### PR TITLE
Remove Parsing Variables with Single Dollar

### DIFF
--- a/src/utils/utils.js
+++ b/src/utils/utils.js
@@ -70,10 +70,16 @@ export function updateNameField(currentValueLabel, currentValueName) {
 }
 
 export function verifyVariable(label) {
-  const numSigns = (label.match(/\$/g) || []).length;
 
-  if (numSigns === 1) {
-    label = `${label}$`
+  const expression = (/\$([^\s]+)/g);
+  const variables = label.match(expression);
+
+  if (variables) {
+    variables.forEach(variable => {
+      if (variable[variable.length - 1] !== '$') {
+        label = label.replace(variable, variable+'$');
+      }
+    })
   }
 
   return label;

--- a/src/utils/utils.js
+++ b/src/utils/utils.js
@@ -68,3 +68,13 @@ export function updateNameField(currentValueLabel, currentValueName) {
 
   return value;
 }
+
+export function verifyVariable(label) {
+  const numSigns = (label.match(/\$/g) || []).length;
+
+  if (numSigns === 1) {
+    label = `${label}$`
+  }
+
+  return label;
+}

--- a/src/utils/utils.spec.js
+++ b/src/utils/utils.spec.js
@@ -18,10 +18,8 @@ describe('Utils', () => {
   test('storeToArray', () => {
     expect(storeToArray()).toEqual([]);
   });
-
   test('verifyVariable', () => {
     const label = 'Value0: $Value1 $Value2 $Value3$ Value4';
     expect(verifyVariable(label)).toBe('Value0: $Value1$ $Value2$ $Value3$ Value4');
   });
-
 });

--- a/src/utils/utils.spec.js
+++ b/src/utils/utils.spec.js
@@ -1,4 +1,4 @@
-import { getUrlFromCriterias, storeToArray } from './utils';
+import { getUrlFromCriterias, storeToArray, verifyVariable } from './utils';
 
 describe('Utils', () => {
   test('getUrlFromCriterias', () => {
@@ -18,4 +18,10 @@ describe('Utils', () => {
   test('storeToArray', () => {
     expect(storeToArray()).toEqual([]);
   });
+
+  test('verifyVariable', () => {
+    const label = 'Value0: $Value1 $Value2 $Value3$ Value4';
+    expect(verifyVariable(label)).toBe('Value0: $Value1$ $Value2$ $Value3$ Value4');
+  });
+
 });

--- a/src/widgets/component-new-edit/model/component.js
+++ b/src/widgets/component-new-edit/model/component.js
@@ -6,7 +6,7 @@ import CollectedVariable from './collected-variable';
 import CalculatedVariable from './calculated-variable';
 import ExternalVariable from './external-variable';
 
-import { uuid, nameFromLabel } from 'utils/utils';
+import { uuid, nameFromLabel, verifyVariable } from 'utils/utils';
 import { COMPONENT_TYPE } from 'constants/pogues-constants';
 
 const { QUESTION } = COMPONENT_TYPE;
@@ -47,7 +47,7 @@ export function formToState(form, transformers) {
     declarations: transformers.declaration.formToComponentState(declarations),
     controls: transformers.control.formToComponentState(controls),
     redirections: transformers.redirection.formToComponentState(redirections),
-    label: label,
+    label: verifyVariable(label),
     responseFormat: transformers.responseFormat.formToState(responseFormat),
     collectedVariables: transformers.collectedVariable.formToComponentState(
       collectedVariables,

--- a/src/widgets/component-new-edit/model/control.js
+++ b/src/widgets/component-new-edit/model/control.js
@@ -1,4 +1,4 @@
-import { uuid } from 'utils/utils';
+import { uuid, verifyVariable } from 'utils/utils';
 
 export const defaultState = {
   label: '',
@@ -34,8 +34,8 @@ export function formToState(form) {
   return {
     id,
     label,
-    condition,
-    message,
+    condition: verifyVariable(condition),
+    message: verifyVariable(message),
     criticity,
     during_collect,
     post_collect,

--- a/src/widgets/component-new-edit/model/declaration.js
+++ b/src/widgets/component-new-edit/model/declaration.js
@@ -1,4 +1,4 @@
-import { uuid } from 'utils/utils';
+import { uuid, verifyVariable } from 'utils/utils';
 
 export const defaultState = {
   declarationType: 'INSTRUCTION',
@@ -20,7 +20,7 @@ export function formToState(form) {
 
   return {
     id,
-    label,
+    label: verifyVariable(label),
     declarationType,
     position,
   };

--- a/src/widgets/component-new-edit/model/response-format-table.js
+++ b/src/widgets/component-new-edit/model/response-format-table.js
@@ -1,6 +1,6 @@
 import merge from 'lodash.merge';
 import cloneDeep from 'lodash.clonedeep';
-import { uuid } from 'utils/utils';
+import { uuid, verifyVariable } from 'utils/utils';
 
 import { CodesListModel } from 'widgets/codes-lists';
 import {
@@ -156,7 +156,7 @@ export function formToStateSecondary(form, codesListSecondary) {
 export function formToStateMeasure(form, codesListMeasure) {
   const { label, type, [type]: measureForm } = form;
   const state = {
-    label,
+    label: verifyVariable(label),
     type,
   };
 


### PR DESCRIPTION
263 -FO- Retirer la parsing sur les variables avec un seul dollar (générateur DDI)

This checks for variables in labels, upon Validation, and, if they have a single $ (e.g. `$VAR`), adds a $ at the end (`$VAR$`).