### PR TITLE
[FIX] Validation not working with Date format

### DIFF
--- a/src/widgets/component-new-edit/components/response-format/simple/simple-date.jsx
+++ b/src/widgets/component-new-edit/components/response-format/simple/simple-date.jsx
@@ -64,14 +64,16 @@ class ResponseFormatDatatypeDate extends Component {
             </GenericOption>
 
           </Field>   
-         <div hidden = {formatini == ''}>
+         <div hidden = {formatini == '' && !this.props.collectedFormat}>
           <Field
             name="minimum"
             type="text"
             step="any"
             component={Input}
             label={Dictionary.minimum}
-            validate = {date({ format: formatini, message: Dictionary.formatDate? Dictionary.formatDate: '', allowBlank: true })}
+            validate = {!this.props.collectedFormat ? 
+              date({ format: formatini, message: Dictionary.formatDate? Dictionary.formatDate: '', allowBlank: true })
+              : false}
             disabled={this.props.readOnly}
           />
           <Field
@@ -80,7 +82,9 @@ class ResponseFormatDatatypeDate extends Component {
             step="any"
             component={Input}
             label={Dictionary.maximum}
-            validate = {date({ format: formatini, message: Dictionary.formatDate? Dictionary.formatDate: '', allowBlank: true })}
+            validate = {!this.props.collectedFormat ? 
+              date({ format: formatini, message: Dictionary.formatDate? Dictionary.formatDate: '', allowBlank: true })
+              : false}
             disabled={this.props.readOnly}
           />
          </div>

--- a/src/widgets/component-new-edit/components/response-format/simple/simple-date.jsx
+++ b/src/widgets/component-new-edit/components/response-format/simple/simple-date.jsx
@@ -22,6 +22,11 @@ class ResponseFormatDatatypeDate extends Component {
     if(this.props.type === 'TABLE'){
       formatini = this.props.formattable; 
     }
+
+    const validation = !this.props.collectedFormat ? 
+      date({ format: formatini, message: Dictionary.formatDate? Dictionary.formatDate: '', allowBlank: true })
+      : false;
+
     return (
 
       <FormSection name={this.props.name}>
@@ -64,16 +69,14 @@ class ResponseFormatDatatypeDate extends Component {
             </GenericOption>
 
           </Field>   
-         <div hidden = {formatini == '' && !this.props.collectedFormat}>
+         <div hidden={formatini === '' && !this.props.collectedFormat}>
           <Field
             name="minimum"
             type="text"
             step="any"
             component={Input}
             label={Dictionary.minimum}
-            validate = {!this.props.collectedFormat ? 
-              date({ format: formatini, message: Dictionary.formatDate? Dictionary.formatDate: '', allowBlank: true })
-              : false}
+            validate={validation}
             disabled={this.props.readOnly}
           />
           <Field
@@ -82,9 +85,7 @@ class ResponseFormatDatatypeDate extends Component {
             step="any"
             component={Input}
             label={Dictionary.maximum}
-            validate = {!this.props.collectedFormat ? 
-              date({ format: formatini, message: Dictionary.formatDate? Dictionary.formatDate: '', allowBlank: true })
-              : false}
+            validate={validation}
             disabled={this.props.readOnly}
           />
          </div>

--- a/src/widgets/component-new-edit/components/variables/collected-variables.jsx
+++ b/src/widgets/component-new-edit/components/variables/collected-variables.jsx
@@ -155,7 +155,7 @@ class CollectedVariables extends Component {
               <ResponseFormatDatatypeText readOnly required={false} />
             </View>
             <View key={DATE} value={DATE} label={Dictionary.DATE} >
-              <ResponseFormatDatatypeDate readOnly required={false} />
+              <ResponseFormatDatatypeDate readOnly required={false} collectedFormat={true}/>
             </View>
             <View key={NUMERIC} value={NUMERIC} label={Dictionary.NUMERIC}>
               <ResponseFormatDatatypeNumeric readOnly required={false} />


### PR DESCRIPTION
273A3-Impossible de modifier les identifiants de variables collectées correspondant à une colonne de dates dans un tableau

This fixes a bug where `minimum` and `maximum` of format `Date` were not being passed into the Collected Variables tab, which prevented validation.