### PR TITLE
fix: import code list values

### DIFF
--- a/src/widgets/codes-lists/components/codes-lists-codes.jsx
+++ b/src/widgets/codes-lists/components/codes-lists-codes.jsx
@@ -63,7 +63,7 @@ function CodesListsCodes(props) {
         removeAll();
         codes.forEach((code, index) => {
           code.value = code.value.toString();
-          code.weight = index;
+          code.weight = index + 1;
           code.depth = allCodes[0]?.depth || 1;
           code.parent = code.parent || '';
           push(code);

--- a/src/widgets/codes-lists/components/codes-lists-codes.jsx
+++ b/src/widgets/codes-lists/components/codes-lists-codes.jsx
@@ -62,6 +62,7 @@ function CodesListsCodes(props) {
       if (codes && codes.length > 0) {
         removeAll();
         codes.forEach((code, index) => {
+          code.value = code.value.toString();
           code.weight = index;
           code.depth = allCodes[0]?.depth || 1;
           code.parent = code.parent || '';


### PR DESCRIPTION
- #788 
  - when importing code list, the type of its value was different than when we create the code list (number instead of string)

- #789 
  - when importing code list, the weight for each modality was different than when we create the code list (starting from 0 instead of 1)

