### PR TITLE
fix: display control scope on new roundabout

### DIFF
--- a/src/widgets/component-new-edit/components/controls.jsx
+++ b/src/widgets/component-new-edit/components/controls.jsx
@@ -132,7 +132,6 @@ const mapStateToProps = (state, { formName }) => {
         state,
         `${TABS_PATHS.RESPONSE_FORMAT}.${QUESTION_TYPE_ENUM.TABLE}.${DIMENSION_TYPE.PRIMARY}.type`,
       ) === DIMENSION_FORMATS.LIST,
-    isRoundabout: selector(state, `locked`) !== undefined,
   };
 };
 

--- a/src/widgets/component-new-edit/components/sequence-new-edit.jsx
+++ b/src/widgets/component-new-edit/components/sequence-new-edit.jsx
@@ -93,6 +93,7 @@ export const SequenceNewEdit = ({
             <Controls
               errors={errorsIntegrityByTab[TABS_PATHS.CONTROLS]}
               addErrors={addSubformValidationErrors}
+              isRoundabout={true}
             />
           </Tab>
         </Tabs>


### PR DESCRIPTION
fix on what has been done for https://github.com/InseeFr/Pogues/issues/792 :

> Impossible d'associer le niveau de criticité du contrôle au moment de la création du rond-point

