### PR TITLE
Fix/cant create survey in demo

### DIFF
--- a/src/utils/validation/validation-rules.jsx
+++ b/src/utils/validation/validation-rules.jsx
@@ -47,10 +47,11 @@ const {
   COLLECTED_VARIABLES,
 } = TABS_PATHS;
 
+//Disabled validation rules for series to implement specific validation rules for series
 export const questionnaireRules = {
-  serie: [requiredSelect],
-  operation: [requiredSelect],
-  campaigns: [required],
+  serie: [],
+  operation: [],
+  campaigns: [],
   name: [required, name],
   label: [required],
   TargetMode: [required],

--- a/src/widgets/questionnaire-new-edit/components/questionnaire-new-edit.jsx
+++ b/src/widgets/questionnaire-new-edit/components/questionnaire-new-edit.jsx
@@ -57,6 +57,7 @@ function QuestionnaireNewEdit({
           component={ListCheckboxes}
           label={Dictionary.collectionMode}
           inline
+          required
         >
           {TargetMode.map((s) => (
             <GenericOption key={s.value} value={s.value}>
@@ -69,6 +70,7 @@ function QuestionnaireNewEdit({
           component={ListRadios}
           label={Dictionary.dynamiqueSpecified}
           inline
+          required
         >
           <GenericOption key={Redirections} value={Redirections}>
             {Dictionary.QGoTo}
@@ -82,6 +84,7 @@ function QuestionnaireNewEdit({
           component={ListRadios}
           label={Dictionary.formulaSpecified}
           inline
+          required
         >
           <GenericOption key={XPATH} value={XPATH}>
             {Dictionary.formulaXpath}

--- a/src/widgets/statistical-context-criteria/containers/statistical-context-criteria.jsx
+++ b/src/widgets/statistical-context-criteria/containers/statistical-context-criteria.jsx
@@ -86,7 +86,7 @@ export const mapStateToProps = (
             ...storeToArray(state?.metadataByType?.series),
           ]
         : storeToArray(state?.metadataByType?.series),
-    required: state?.metadataByType?.series?.length > 0,
+    required: Object.keys(state?.metadataByType?.series ?? {}).length > 0,
     selectedSerie,
     path,
   };

--- a/src/widgets/statistical-context-criteria/containers/statistical-context-criteria.jsx
+++ b/src/widgets/statistical-context-criteria/containers/statistical-context-criteria.jsx
@@ -86,6 +86,7 @@ export const mapStateToProps = (
             ...storeToArray(state?.metadataByType?.series),
           ]
         : storeToArray(state?.metadataByType?.series),
+    required: state?.metadataByType?.series?.length > 0,
     selectedSerie,
     path,
   };


### PR DESCRIPTION
- Make series-related fields optional if no series are retrieved from the backend or mock data.
- Minor UI adjustment to indicate mandatory fields.