### PR TITLE
feat: move and rename 'scope' component

### DIFF
--- a/src/constants/dictionary.js
+++ b/src/constants/dictionary.js
@@ -149,7 +149,7 @@ const dictionary = {
   },
   Scope: {
     en: 'Scope',
-    fr: 'Portée',
+    fr: 'Niveau de calcul',
   },
   question: {
     en: 'Question',

--- a/src/model/transformations/external-variable.spec.jsx
+++ b/src/model/transformations/external-variable.spec.jsx
@@ -1,8 +1,7 @@
 import { describe, expect, it } from 'vitest';
 
-import { remoteToStore, storeToRemote } from './external-variable';
-
 import { DATATYPE_NAME } from '../../constants/pogues-constants';
+import { remoteToStore, storeToRemote } from './external-variable';
 
 const { TEXT, NUMERIC } = DATATYPE_NAME;
 

--- a/src/widgets/component-new-edit/components/variables/calculated-variables.jsx
+++ b/src/widgets/component-new-edit/components/variables/calculated-variables.jsx
@@ -86,6 +86,12 @@ const CalculatedVariables = ({
           required
           setDisableValidation={setDisableValidation}
         />
+        <Field name="scope" component={Select} label={Dictionary.Scope}>
+          <GenericOption key="" value="">
+            {Dictionary.selectScope}
+          </GenericOption>
+          {scopes}
+        </Field>
         <SelectorView
           label={Dictionary.responseType}
           selectorPath={selectorPath}
@@ -105,12 +111,6 @@ const CalculatedVariables = ({
           </View>
           <View key={BOOLEAN} value={BOOLEAN} label={Dictionary.BOOLEAN} />
         </SelectorView>
-        <Field name="scope" component={Select} label={Dictionary.Scope}>
-          <GenericOption key="" value="">
-            {Dictionary.selectScope}
-          </GenericOption>
-          {scopes}
-        </Field>
       </ListWithInputPanel>
     </FormSection>
   );

--- a/src/widgets/component-new-edit/components/variables/external-variables.jsx
+++ b/src/widgets/component-new-edit/components/variables/external-variables.jsx
@@ -76,6 +76,12 @@ function ExternalVariables({
           label={Dictionary.name}
           required
         />
+        <Field name="scope" component={Select} label={Dictionary.Scope}>
+          <GenericOption key="" value="">
+            {Dictionary.selectScope}
+          </GenericOption>
+          {scopes}
+        </Field>
         <SelectorView
           label={Dictionary.responseType}
           selectorPath={selectorPath}
@@ -95,12 +101,6 @@ function ExternalVariables({
           </View>
           <View key={BOOLEAN} value={BOOLEAN} label={Dictionary.BOOLEAN} />
         </SelectorView>
-        <Field name="scope" component={Select} label={Dictionary.Scope}>
-          <GenericOption key="" value="">
-            {Dictionary.selectScope}
-          </GenericOption>
-          {scopes}
-        </Field>
       </ListWithInputPanel>
     </FormSection>
   );


### PR DESCRIPTION
[Issue #101](https://github.com/InseeFr/Concevoir-Workplace/issues/101)

The entry "selectScope" in the dictionary was not modified as I found "Niveau de calcul du questionnaire" a bit heavy for the user to read, and it makes the field more confusing.