### PR TITLE
feat: remove unit on numeric calculated variable

### DIFF
--- a/src/widgets/component-new-edit/components/response-format/simple/simple-numeric.jsx
+++ b/src/widgets/component-new-edit/components/response-format/simple/simple-numeric.jsx
@@ -1,3 +1,4 @@
+import PropTypes from 'prop-types';
 import { connect } from 'react-redux';
 import { Field, FormSection, change, formValueSelector } from 'redux-form';
 
@@ -19,13 +20,18 @@ function mapUnitData(unit) {
   };
 }
 
+/**
+ * Give information for a numeric variable (collected, external, or calculated variable).
+ *
+ * - disableSetUnit : allows to disable the fields concerning the measurement unit, not wanted for calculated variables
+ */
 function ResponseFormatDatatypeNumeric({
-  name,
-  required,
-  readOnly,
+  name = NUMERIC,
+  required = true,
+  readOnly = false,
   isDynamicUnit,
   setUnit,
-  enableSetUnit,
+  disableSetUnit = false,
 }) {
   const handleDynamicUnitChange = () => {
     setUnit('');
@@ -60,7 +66,7 @@ function ResponseFormatDatatypeNumeric({
           label={Dictionary.decimals}
           disabled={readOnly}
         />
-        {enableSetUnit && (
+        {!disableSetUnit && (
           <>
             <Field
               name="isDynamicUnit"
@@ -102,11 +108,13 @@ function ResponseFormatDatatypeNumeric({
   );
 }
 
-ResponseFormatDatatypeNumeric.defaultProps = {
-  name: NUMERIC,
-  readOnly: false,
-  required: true,
-  enableSetUnit: true,
+ResponseFormatDatatypeNumeric.propTypes = {
+  name: PropTypes.string,
+  readOnly: PropTypes.bool,
+  required: PropTypes.bool,
+  isDynamicUnit: PropTypes.bool,
+  setUnit: PropTypes.func,
+  disableSetUnit: PropTypes.bool,
 };
 
 // Container

--- a/src/widgets/component-new-edit/components/response-format/simple/simple-numeric.jsx
+++ b/src/widgets/component-new-edit/components/response-format/simple/simple-numeric.jsx
@@ -25,6 +25,7 @@ function ResponseFormatDatatypeNumeric({
   readOnly,
   isDynamicUnit,
   setUnit,
+  enableSetUnit,
 }) {
   const handleDynamicUnitChange = () => {
     setUnit('');
@@ -59,37 +60,42 @@ function ResponseFormatDatatypeNumeric({
           label={Dictionary.decimals}
           disabled={readOnly}
         />
-        <Field
-          name="isDynamicUnit"
-          component={ListRadios}
-          label={Dictionary.dynamicUnit}
-          disabled={readOnly}
-          onChange={handleDynamicUnitChange}
-          required
-          // Convert string "true"/"false" to boolean true/false when storing in Redux form
-          parse={(value) => value === 'true'}
-          // Convert true/false/undefined to string "true"/"false" when displaying the form
-          format={(value) => (value === true ? 'true' : 'false')}
-        >
-          <GenericOption value="true">{Dictionary.yes}</GenericOption>
-          <GenericOption value="false">{Dictionary.no}</GenericOption>
-        </Field>
-        {isDynamicUnit ? (
-          <Field
-            name="unit"
-            component={RichEditorWithVariable}
-            label={Dictionary.dynamicUnitFormula}
-            disabled={readOnly}
-          />
-        ) : (
-          <SelectMetaDataContainer
-            type="units"
-            name="unit"
-            label={Dictionary.unit}
-            emptyValue={Dictionary.unitEmptySelect}
-            mapMetadataFunction={mapUnitData}
-            disabled={readOnly}
-          />
+        {enableSetUnit && (
+          <>
+            <Field
+              name="isDynamicUnit"
+              component={ListRadios}
+              label={Dictionary.dynamicUnit}
+              disabled={readOnly}
+              onChange={handleDynamicUnitChange}
+              required
+              // Convert string "true"/"false" to boolean true/false when storing in Redux form
+              parse={(value) => value === 'true'}
+              // Convert true/false/undefined to string "true"/"false" when displaying the form
+              format={(value) => (value === true ? 'true' : 'false')}
+            >
+              <GenericOption value="true">{Dictionary.yes}</GenericOption>
+              <GenericOption value="false">{Dictionary.no}</GenericOption>
+            </Field>
+
+            {isDynamicUnit ? (
+              <Field
+                name="unit"
+                component={RichEditorWithVariable}
+                label={Dictionary.dynamicUnitFormula}
+                disabled={readOnly}
+              />
+            ) : (
+              <SelectMetaDataContainer
+                type="units"
+                name="unit"
+                label={Dictionary.unit}
+                emptyValue={Dictionary.unitEmptySelect}
+                mapMetadataFunction={mapUnitData}
+                disabled={readOnly}
+              />
+            )}
+          </>
         )}
       </div>
     </FormSection>
@@ -100,6 +106,7 @@ ResponseFormatDatatypeNumeric.defaultProps = {
   name: NUMERIC,
   readOnly: false,
   required: true,
+  enableSetUnit: true,
 };
 
 // Container

--- a/src/widgets/component-new-edit/components/variables/calculated-variables.jsx
+++ b/src/widgets/component-new-edit/components/variables/calculated-variables.jsx
@@ -107,7 +107,7 @@ const CalculatedVariables = ({
             <ResponseFormatDatatypeNumeric
               selectorPath={selectorPath}
               required
-              enableSetUnit={false}
+              disableSetUnit={true}
             />
           </View>
           <View key={BOOLEAN} value={BOOLEAN} label={Dictionary.BOOLEAN} />

--- a/src/widgets/component-new-edit/components/variables/calculated-variables.jsx
+++ b/src/widgets/component-new-edit/components/variables/calculated-variables.jsx
@@ -107,6 +107,7 @@ const CalculatedVariables = ({
             <ResponseFormatDatatypeNumeric
               selectorPath={selectorPath}
               required
+              enableSetUnit={false}
             />
           </View>
           <View key={BOOLEAN} value={BOOLEAN} label={Dictionary.BOOLEAN} />


### PR DESCRIPTION
For calculated variables, if the response type is numeric : remove all the fields relative to its measurement unit.

---

As the model of numeric variable is shared for every numeric variable type (collected, external, calculated) and isDynamicUnit is mandatory, i voluntarily did not change the transformations (form/state/model).
So even if we cannot set a unit anymore, in the model we keep unit='' with isDynamicUnit=false (that were already the default values for every numeric variable type)