### PR TITLE
feat: remove unit on numeric external variable

### DIFF
--- a/src/widgets/component-new-edit/components/variables/external-variables.jsx
+++ b/src/widgets/component-new-edit/components/variables/external-variables.jsx
@@ -97,6 +97,7 @@ function ExternalVariables({
             <ResponseFormatDatatypeNumeric
               selectorPath={selectorPath}
               required
+              disableSetUnit={true}
             />
           </View>
           <View key={BOOLEAN} value={BOOLEAN} label={Dictionary.BOOLEAN} />


### PR DESCRIPTION
For external variables, if the response type is numeric : remove all the fields relative to its measurement unit.

see what has been done for calculated variables : https://github.com/InseeFr/Pogues/pull/898