### PR TITLE
fix: cache strategy for compatibility with beta

### DIFF
--- a/next/vite.config.ts
+++ b/next/vite.config.ts
@@ -15,7 +15,7 @@ export default defineConfig(({ mode }) => ({
         '@pogues-legacy': {
           type: 'module',
           name: '@pogues-legacy',
-          entry: 'http://localhost:5145/remoteEntry.js',
+          entry: 'http://localhost:5145/remote-entry.js',
         },
       },
       shared: mode === 'development' ? [] : ['react/', 'react-dom/'],

--- a/nginx.conf
+++ b/nginx.conf
@@ -7,10 +7,12 @@ server {
 
     location = /env-config.js {
       expires -1;
-      # access_log logs/static.log; # I don't usually include a static log
+    }
+    location = /remote-entry.js {
+      expires -1;
     }
 
-    location ~* \.(?:manifest|appcache|html?|xml|json|env-config.js)$ {
+    location ~* \.(?:manifest|appcache|html?|xml|json)$ {
       expires -1;
       # access_log logs/static.log; # I don't usually include a static log
     }

--- a/package.json
+++ b/package.json
@@ -32,7 +32,7 @@
   "scripts": {
     "start": "vite --port 5145",
     "build": "npm run generate-entrypoint && vite build",
-    "postbuild": "node scripts/remote-env.cjs remoteEntry.js",
+    "postbuild": "node scripts/remote-env.cjs remote-entry.js",
     "preview": "vite preview --port 5145",
     "test": "vitest run",
     "test:watch": "vitest",

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -20,7 +20,7 @@ export const buildViteConf = (withFederation: boolean): UserConfig => {
           ...defaultPlugin,
           federation({
             name: '@pogues-legacy',
-            filename: 'remoteEntry.js',
+            filename: 'remote-entry.js',
             exposes: {
               './App': './src/main.jsx',
             },


### PR DESCRIPTION
J'ai du change le nom du fichier `remoteEntry.js` en `remote-entry.js` car nous avons déjà en production le fichier `remoteEntry.js` (qui en cache et expire dans un an)

Pour éviter tout pb de cache, on change le nom du fichier et on fait en sorte que celui-ci n'expire jamais comme le fichier `env-config.js` (via la configuration du nginx)

Pour assurer la compatibilité avec la beta (next), il faudra faire la montée de version en même temps pour les deux.