### PR TITLE
feat: add pogues model download

### DIFF
--- a/sonar-project.properties
+++ b/sonar-project.properties
@@ -15,7 +15,7 @@ sonar.test.inclusions=src/**/*.spec.jsx
 
 # Coverage
 sonar.javascript.lcov.reportPaths=./coverage/lcov.info
-sonar.coverage.exclusions=src/**/*.spec.jsx
+sonar.coverage.exclusions=src/**/*.spec.js, src/**/*.spec.jsx, src/**/*.spec.ts, src/**/*.spec.tsx
 
 # Source encoding
 sonar.sourceEncoding=UTF-8

--- a/src/api/utils.ts
+++ b/src/api/utils.ts
@@ -7,3 +7,24 @@ export function getBaseURI(): string {
 export function computeAuthorizationHeader(token: string): string {
   return token ? `Bearer ${token}` : '';
 }
+
+export function downloadAsJson(params: { data: object; filename?: string }) {
+  const { data, filename = 'data.json' } = params;
+  if (!data) {
+    console.error('No data to download.');
+    return;
+  }
+  const jsonData = JSON.stringify(data, null, 2);
+  const blob = new Blob([jsonData], { type: 'application/json' });
+
+  const url = URL.createObjectURL(blob);
+  const a = document.createElement('a');
+  a.href = url;
+  a.download = filename;
+
+  document.body.appendChild(a);
+  a.click();
+
+  document.body.removeChild(a);
+  URL.revokeObjectURL(url);
+}

--- a/src/api/visualize.spec.ts
+++ b/src/api/visualize.spec.ts
@@ -1,0 +1,27 @@
+import { describe, expect, it, vi } from 'vitest';
+
+import { downloadAsJson } from './utils';
+import { VisualizationKind, getVisualization } from './visualize';
+
+vi.mock('./utils', () => ({
+  downloadAsJson: vi.fn(),
+}));
+
+describe('getVisualization', () => {
+  it('should trigger download for PoguesModel visualization', async () => {
+    const questionnaire = { id: '123', DataCollection: [], Name: 'Test' };
+    const token = 'test-token';
+
+    await getVisualization(
+      VisualizationKind.PoguesModel,
+      questionnaire,
+      true,
+      token,
+    );
+
+    expect(downloadAsJson).toHaveBeenCalledWith({
+      data: questionnaire,
+      filename: `model_${questionnaire.id}.json`,
+    });
+  });
+});

--- a/src/api/visualize.ts
+++ b/src/api/visualize.ts
@@ -1,10 +1,15 @@
-import { computeAuthorizationHeader, getBaseURI } from './utils';
+import {
+  computeAuthorizationHeader,
+  downloadAsJson,
+  getBaseURI,
+} from './utils';
 
 type QuestionnaireData = {
   id: string;
 };
 
 type Questionnaire = {
+  id: string;
   DataCollection: QuestionnaireData[];
   Name: string;
 };
@@ -13,6 +18,7 @@ export const enum VisualizationKind {
   PDF,
   Spec,
   DDI,
+  PoguesModel,
   HTML,
   Household,
   Business,
@@ -116,6 +122,11 @@ export async function getVisualization(
           document.body.appendChild(a);
           a.click();
         });
+    case VisualizationKind.PoguesModel:
+      downloadAsJson({
+        data: qr,
+        filename: `model_${qr.id}.json`,
+      });
   }
 
   return null;

--- a/src/constants/dictionary.ts
+++ b/src/constants/dictionary.ts
@@ -927,9 +927,13 @@ const dictionary: Dictionary = {
     fr: 'Spécification',
     en: 'Specification',
   },
-  VISUALIZE_DDI: {
+  VISUALIZE_POGUES_MODEL: {
     fr: 'Métadonnées',
     en: 'Metadata',
+  },
+  VISUALIZE_DDI: {
+    fr: 'Documentation (DDI)',
+    en: 'Documentation (DDI)',
   },
   NEW: {
     fr: 'Nouveau',

--- a/src/widgets/visualize-dropdown/__snapshots__/visualize-dropdown.spec.tsx.snap
+++ b/src/widgets/visualize-dropdown/__snapshots__/visualize-dropdown.spec.tsx.snap
@@ -80,6 +80,13 @@ exports[`Visualize Dropdown Component:  > Should disable the button 1`] = `
             Metadata
           </a>
         </li>
+        <li>
+          <a
+            href="#"
+          >
+            Documentation (DDI)
+          </a>
+        </li>
       </ul>
     </div>
     <div
@@ -168,6 +175,13 @@ exports[`Visualize Dropdown Component:  > Should display the dropdown on top 1`]
             Metadata
           </a>
         </li>
+        <li>
+          <a
+            href="#"
+          >
+            Documentation (DDI)
+          </a>
+        </li>
       </ul>
     </div>
     <div
@@ -254,6 +268,13 @@ exports[`Visualize Dropdown Component:  > Should return the right HTML 1`] = `
             href="#"
           >
             Metadata
+          </a>
+        </li>
+        <li>
+          <a
+            href="#"
+          >
+            Documentation (DDI)
           </a>
         </li>
       </ul>

--- a/src/widgets/visualize-dropdown/components/visualize-dropdown.tsx
+++ b/src/widgets/visualize-dropdown/components/visualize-dropdown.tsx
@@ -184,6 +184,10 @@ const dropdownOptions = [
     label: Dictionary.VISUALIZE_SPECIFICATION,
   },
   {
+    type: VisualizationKind.PoguesModel,
+    label: Dictionary.VISUALIZE_POGUES_MODEL,
+  },
+  {
     type: VisualizationKind.DDI,
     label: Dictionary.VISUALIZE_DDI,
   },


### PR DESCRIPTION
Add possibility of downloading the questionnaire model (pogues-model json).

For now we add it in the "Visualize" dropdown
- rename DDI download  => "Documentation (DDI)"
- add questionnaire json download => "Metadata"