### PR TITLE
feat: handle duplicated codes in codeList

### DIFF
--- a/next/src/components/codesLists/form/CodesListForm.test.tsx
+++ b/next/src/components/codesLists/form/CodesListForm.test.tsx
@@ -1,0 +1,144 @@
+import { fireEvent, screen, waitFor } from '@testing-library/react';
+
+import { renderWithRouter } from '@/utils/tests';
+
+import CodesListForm from './CodesListForm';
+
+vi.mock('@/components/ui/VTLEditor');
+
+it('should enable the button only when all fields are filled', async () => {
+  const submitFn = vi.fn();
+  renderWithRouter(
+    <CodesListForm
+      questionnaireId="q-id"
+      onSubmit={submitFn}
+      variables={[]}
+      submitLabel="Submit label"
+    />,
+  );
+
+  await waitFor(() => {
+    expect(
+      screen.getByRole('button', { name: /Submit label/i }),
+    ).toBeDisabled();
+  });
+
+  fireEvent.input(screen.getByRole('textbox', { name: /Label/i }), {
+    target: {
+      value: 'my label',
+    },
+  });
+
+  await waitFor(() => {
+    expect(
+      screen.getByRole('button', { name: /Submit label/i }),
+    ).toBeDisabled();
+  });
+
+  fireEvent.input(screen.getByTestId('codes.0.value'), {
+    target: {
+      value: 'my code value',
+    },
+  });
+  fireEvent.input(screen.getByTestId('codes.0.label'), {
+    target: {
+      value: 'my code label',
+    },
+  });
+
+  await waitFor(() => {
+    expect(screen.getByRole('button', { name: /Submit label/i })).toBeEnabled();
+  });
+
+  fireEvent.submit(screen.getByRole('button', { name: /Submit label/i }));
+  await waitFor(() => {
+    expect(submitFn).toBeCalled();
+  });
+});
+
+it('should display "must have label" error when empty', async () => {
+  renderWithRouter(
+    <CodesListForm
+      questionnaireId="q-id"
+      onSubmit={vi.fn()}
+      submitLabel="Submit label"
+    />,
+  );
+
+  fireEvent.input(screen.getByRole('textbox', { name: /Label/i }), {
+    target: { value: 'my label' },
+  });
+  fireEvent.input(screen.getByRole('textbox', { name: /Label/i }), {
+    target: { value: '' },
+  });
+
+  expect(await screen.findAllByRole('alert')).toHaveLength(1);
+  expect(screen.getByText('You must provide a label')).toBeDefined();
+});
+
+it('should display "code must have value" error when empty', async () => {
+  renderWithRouter(
+    <CodesListForm
+      questionnaireId="q-id"
+      onSubmit={vi.fn()}
+      submitLabel="Submit label"
+    />,
+  );
+
+  fireEvent.input(screen.getByTestId('codes.0.value'), {
+    target: { value: 'my code value' },
+  });
+  fireEvent.input(screen.getByTestId('codes.0.value'), {
+    target: { value: '' },
+  });
+
+  expect((await screen.findAllByRole('alert')).length).toBeGreaterThanOrEqual(
+    1,
+  );
+  expect(screen.getByText('Your code must have a value')).toBeDefined();
+});
+
+it('should display "code must have label" error when empty', async () => {
+  renderWithRouter(
+    <CodesListForm
+      questionnaireId="q-id"
+      onSubmit={vi.fn()}
+      submitLabel="Submit label"
+    />,
+  );
+
+  fireEvent.input(screen.getByTestId('codes.0.label'), {
+    target: { value: 'my code value' },
+  });
+  fireEvent.input(screen.getByTestId('codes.0.label'), {
+    target: { value: '' },
+  });
+
+  expect(await screen.findAllByRole('alert')).toHaveLength(1);
+  expect(screen.getByText('Your code must have a label')).toBeDefined();
+});
+
+it('should display "value must be unique" error when duplicate value', async () => {
+  renderWithRouter(
+    <CodesListForm
+      questionnaireId="q-id"
+      onSubmit={vi.fn()}
+      submitLabel="Submit label"
+    />,
+  );
+
+  fireEvent.click(screen.getByRole('button', { name: /Add a code/i }));
+  fireEvent.input(screen.getByTestId('codes.0.value'), {
+    target: { value: 'abc' },
+  });
+  fireEvent.input(screen.getByTestId('codes.1.value'), {
+    target: { value: 'abc' },
+  });
+
+  expect((await screen.findAllByRole('alert')).length).toBeGreaterThanOrEqual(
+    2,
+  );
+  expect(
+    await screen.findAllByText('Value must be unique: "abc"'),
+  ).toHaveLength(2);
+});

--- a/next/src/components/ui/Input.tsx
+++ b/next/src/components/ui/Input.tsx
@@ -1,15 +1,16 @@
-import React, { useRef } from 'react';
+import React from 'react';
 
 import { Field } from '@base-ui-components/react/field';
 import { Input as UIInput } from '@base-ui-components/react/input';
 
 interface InputProps extends React.InputHTMLAttributes<HTMLInputElement> {
+  className?: string;
   description?: string;
   error?: string;
   label?: string;
 }
 
-const Input = React.forwardRef<HTMLInputElement>(
+const Input = React.forwardRef<HTMLInputElement, InputProps>(
   (
     {
       className = '',
@@ -44,7 +45,11 @@ const Input = React.forwardRef<HTMLInputElement>(
           className="w-full text-sm font-sans font-normal p-4 rounded-lg shadow-xs border border-default hover:enabled:border-primary focus:enabled:border-primary bg-default text-default placeholder:text-placeholder disabled:text-disabled disabled:bg-disabled focus-visible:outline focus-visible:outline-1 focus-visible:outline-primary"
           {...props}
         />
-        <Field.Error className="text-sm text-error ml-1" forceShow={!!error}>
+        <Field.Error
+          className="text-sm text-error ml-1"
+          forceShow={!!error}
+          role="alert"
+        >
           {error}
         </Field.Error>
 

--- a/next/src/components/ui/__mocks__/VTLEditor.tsx
+++ b/next/src/components/ui/__mocks__/VTLEditor.tsx
@@ -1,0 +1,9 @@
+import Input from '../Input';
+
+interface VTLEditorProps extends React.InputHTMLAttributes<HTMLInputElement> {
+  error?: string;
+}
+
+export default function VTLEditor({ error }: Readonly<VTLEditorProps>) {
+  return <Input className="col-start-2" error={error} />;
+}

--- a/next/src/i18n/locales/en.json
+++ b/next/src/i18n/locales/en.json
@@ -93,6 +93,7 @@
       "mustProvideCodeLabel": "Your code must have a label",
       "mustProvideCodeValue": "Your code must have a value",
       "mustProvideCodes": "You must provide at least one code",
+      "mustProvideUniqueValue": "Value must be unique: \"{{value}}\"",
       "moveUp": "Move up",
       "moveDown": "Move down"
     }

--- a/next/src/i18n/locales/fr.json
+++ b/next/src/i18n/locales/fr.json
@@ -93,6 +93,7 @@
       "mustProvideCodeLabel": "Votre code doit avoir un label",
       "mustProvideCodeValue": "Votre code doit avoir une valeur",
       "mustProvideCodes": "Vous devez renseigner au moins un code",
+      "mustProvideUniqueValue": "La valeur doit être unique : \"{{value}}\"",
       "moveUp": "Monter d'un niveau",
       "moveDown": "Descendre d'un niveau"
     }


### PR DESCRIPTION
Lors de l'édition d'une codeList, empêcher la validation lorsque 2 codes ont la même valeur (sinon on est incapable de récupérer le questionnaire derrière).

Pour le moment, modification du schema zod pour prendre en compte cette gestion de doublon : lors de la saisie de la valeur, on trigger en continu tous les champs pour recalculer les erreurs. Si plusieurs codes ont la même valeur, alors une erreur de duplication est affichée sous tous les champs concernés, et la validation de la codeList est impossible.

Reste à faire : 
- rajouter la traduction dans l'erreur de duplication
- sans doute modifier le message de l'erreur de duplication
- voir si l'on souhaite vraiment trigger les erreurs de duplication en continu (peut être perturbant qu'en cours de saisie on ait des erreurs qui pop) , ou si on les trigger uniquement au moment de la validation
- voir si on peut faire plus proprement, c'est assez brut pour l'instant
- ajouter des tests