### PR TITLE
fix: remove confirm modal on unload if no dirty state

### DIFF
--- a/next/src/components/legacy/index.tsx
+++ b/next/src/components/legacy/index.tsx
@@ -14,6 +14,8 @@ export const LegacyComponent = () => {
 
   // Block navigation if we are in dirty state
   useBlocker({
+    // enable blocker only if we are in dirty state
+    enableBeforeUnload: isDirtyState,
     shouldBlockFn: () => {
       if (!isDirtyState) return false;
 


### PR DESCRIPTION
On the Legacy component, when user closed the web tab (or navigator) , he always had the confirm modal even if he was not in dirty state

=> enable the blocker only if we are in dirty state