### PR TITLE
feat: remove VTL editor in code card label field & reorder declarations fields

### DIFF
--- a/src/widgets/component-new-edit/components/declarations.jsx
+++ b/src/widgets/component-new-edit/components/declarations.jsx
@@ -12,6 +12,7 @@ import {
 } from '../../../constants/pogues-constants';
 import { RichEditorWithVariable } from '../../../forms/controls/control-with-suggestions';
 import GenericOption from '../../../forms/controls/generic-option';
+import Input from '../../../forms/controls/input';
 import ListCheckboxes from '../../../forms/controls/list-checkboxes';
 import Select from '../../../forms/controls/select';
 import {
@@ -58,18 +59,26 @@ const Declarations = ({
         resetObject={defaultCustum(activeQuestionnaire, defaultDeclaration)}
         disableValidation={disableValidation}
       >
-        <Field
-          name="label"
-          id="declaration_text"
-          component={RichEditorWithVariable}
-          label={
-            declarationType === DECLARATION_TYPES.CODE_CARD
-              ? Dictionary.declaration_label_code_card
-              : Dictionary.declaration_label
-          }
-          required
-          setDisableValidation={setDisableValidation}
-        />
+        {declarationType === DECLARATION_TYPES.CODE_CARD ? (
+          <Field
+            name="label"
+            id="declaration_text"
+            type="text"
+            component={Input}
+            label={Dictionary.declaration_label_code_card}
+            required
+            setDisableValidation={setDisableValidation}
+          />
+        ) : (
+          <Field
+            name="label"
+            id="declaration_text"
+            component={RichEditorWithVariable}
+            label={Dictionary.declaration_label}
+            required
+            setDisableValidation={setDisableValidation}
+          />
+        )}
 
         <Field
           name="declarationType"

--- a/src/widgets/component-new-edit/components/declarations.jsx
+++ b/src/widgets/component-new-edit/components/declarations.jsx
@@ -59,6 +59,24 @@ const Declarations = ({
         resetObject={defaultCustum(activeQuestionnaire, defaultDeclaration)}
         disableValidation={disableValidation}
       >
+        <Field
+          name="declarationType"
+          id="declaration_type"
+          component={Select}
+          label={Dictionary.type}
+          required
+        >
+          <GenericOption value={DECLARATION_TYPES.HELP}>
+            {Dictionary.declarationHelp}
+          </GenericOption>
+          <GenericOption value={DECLARATION_TYPES.INSTRUCTION}>
+            {Dictionary.declarationInstruction}
+          </GenericOption>
+          <GenericOption value={DECLARATION_TYPES.CODE_CARD}>
+            {Dictionary.declarationCodeCard}
+          </GenericOption>
+        </Field>
+
         {declarationType === DECLARATION_TYPES.CODE_CARD ? (
           <Field
             name="label"
@@ -79,24 +97,6 @@ const Declarations = ({
             setDisableValidation={setDisableValidation}
           />
         )}
-
-        <Field
-          name="declarationType"
-          id="declaration_type"
-          component={Select}
-          label={Dictionary.type}
-          required
-        >
-          <GenericOption value={DECLARATION_TYPES.HELP}>
-            {Dictionary.declarationHelp}
-          </GenericOption>
-          <GenericOption value={DECLARATION_TYPES.INSTRUCTION}>
-            {Dictionary.declarationInstruction}
-          </GenericOption>
-          <GenericOption value={DECLARATION_TYPES.CODE_CARD}>
-            {Dictionary.declarationCodeCard}
-          </GenericOption>
-        </Field>
 
         {showPosition && (
           <Field

--- a/src/widgets/component-new-edit/components/declarations.jsx
+++ b/src/widgets/component-new-edit/components/declarations.jsx
@@ -85,7 +85,6 @@ const Declarations = ({
             component={Input}
             label={Dictionary.declaration_label_code_card}
             required
-            setDisableValidation={setDisableValidation}
           />
         ) : (
           <Field

--- a/src/widgets/component-new-edit/components/declarations.spec.jsx
+++ b/src/widgets/component-new-edit/components/declarations.spec.jsx
@@ -1,0 +1,80 @@
+import { render, screen } from '@testing-library/react';
+import { describe, expect, test, vi } from 'vitest';
+
+import { DECLARATION_TYPES } from '../../../constants/pogues-constants';
+import { decoreFormField } from '../../../utils/test/test-utils';
+import Declarations from './declarations';
+
+// need to mock rich editor, else we have .css import error when trying to import Antlr Editor. For now we mock it as an input
+vi.mock('../../../forms/controls/control-with-suggestions', () => ({
+  RichEditorWithVariable: ({ id, label, input }) => (
+    <div>
+      <label htmlFor={id}>{label}</label>
+      <input id={id} {...input} />
+    </div>
+  ),
+}));
+
+// TODO : find a solution to avoid errors without mocking ListWithInputPanel
+vi.mock('../../list-with-input-panel', () => ({
+  ListWithInputPanel: ({ children }) => <div>{children}</div>,
+}));
+
+// TODO : find a better solution to fill the declarationType from a state
+let mockDeclarationType = 'HELP';
+vi.mock('redux-form', async () => {
+  const actual = await vi.importActual('redux-form');
+  return {
+    ...actual,
+    formValueSelector: vi.fn((formName) => {
+      return (state, field) => {
+        if (
+          formName === 'component' &&
+          field === 'declarations.declarationType'
+        ) {
+          return mockDeclarationType;
+        }
+        return undefined;
+      };
+    }),
+  };
+});
+
+describe('Declarations Component', () => {
+  const defaultProps = {
+    activeQuestionnaire: {},
+    addErrors: vi.fn(),
+  };
+
+  test('renders the component with correct fields', () => {
+    render(decoreFormField(<Declarations {...defaultProps} />));
+
+    // type field
+    expect(screen.getByLabelText(/Type/i)).toBeInTheDocument();
+    // label field
+    expect(screen.getByLabelText(/Statement label/i)).toBeInTheDocument();
+    // position field
+    expect(screen.getByLabelText(/Position/i)).toBeInTheDocument();
+    // target mode field
+    expect(screen.getByLabelText(/Collection Mode/i)).toBeInTheDocument();
+  });
+
+  test('does not render position field if showPosition=false', () => {
+    const props = { ...defaultProps, showPosition: false };
+    render(decoreFormField(<Declarations {...props} />));
+
+    expect(screen.queryByLabelText(/Position/i)).not.toBeInTheDocument();
+  });
+
+  test('renders a different label, and as a text input when declaration is a code card', () => {
+    mockDeclarationType = DECLARATION_TYPES.CODE_CARD;
+    render(decoreFormField(<Declarations {...defaultProps} />));
+
+    // Check that the "label" field is rendered as a text input, with a different label
+    expect(screen.getByLabelText(/Code of the card/i)).toHaveAttribute(
+      'type',
+      'text',
+    );
+    expect(screen.queryByLabelText(/Statement label/i)).not.toBeInTheDocument();
+  });
+});


### PR DESCRIPTION
For declarations : 
- reorder fields (set the type first)
- for code cart, change the label field from VTL editor into a simple input

The goal is to simplify removing VTL, and to avoid that the user uses quotes in the label, because they are not handled well then by Eno

---
Some difficulties while adding tests :

- I did not find a way for properly retrieving form state values, if someone has a better idea than my weird mock.

- Without mocking the component using the vtl editor, i had this error : 
`TypeError: Unknown file extension ".css" for C:\Users\PWF0UQ\Documents\git projects\Bowie\Pogues\node_modules\@making-sense\antlr-editor\node_modules\monaco-editor\esm\vs\editor\standalone\browser\standalone-tokens.css `
I did not find a better way, so for now i decided to mock it as an input rendering only what i needed