### PR TITLE
fix: cannot validate card code card declaration

### DIFF
--- a/src/widgets/component-new-edit/components/declarations.jsx
+++ b/src/widgets/component-new-edit/components/declarations.jsx
@@ -1,4 +1,4 @@
-import React, { useState } from 'react';
+import React, { useEffect, useState } from 'react';
 
 import PropTypes from 'prop-types';
 import { connect } from 'react-redux';
@@ -47,6 +47,13 @@ const Declarations = ({
   activeQuestionnaire,
 }) => {
   const [disableValidation, setDisableValidation] = useState(false);
+
+  useEffect(() => {
+    // Reset validation state when switching to code card, since we don't keep VTL editor
+    if (declarationType === DECLARATION_TYPES.CODE_CARD) {
+      setDisableValidation(false);
+    }
+  }, [declarationType]);
 
   return (
     <FormSection name={selectorPath}>


### PR DESCRIPTION
On declaration form, since the default type is `help`, we have the VTL editor (for declaration label).
When switching to code card, we change the VTL editor into a simple input, but we did not reset the disabled validation done by the VTL editor.
So the validation button was always disabled if we have an empty label before hiding VTL editor

=> reset validation used only by VTL editor when switching declaration type to code card