### PR TITLE
feat: enable to filter a dynamic table measure

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "pogues",
-  "version": "1.8.9-rc.0",
+  "version": "1.8.9-rc-table-disabled-cell.0",
   "description": "Outil de conception et de test de questionnaires.",
   "repository": {
     "type": "git",

--- a/src/constants/dictionary/table.ts
+++ b/src/constants/dictionary/table.ts
@@ -42,4 +42,8 @@ export const tableDictionary: Dictionary = {
     fr: 'Information mesurée',
     en: 'Measure information',
   },
+  conditionFilter: {
+    fr: 'Condition de non collecte',
+    en: 'Non-collection condition',
+  },
 };

--- a/src/constants/dictionary/table.ts
+++ b/src/constants/dictionary/table.ts
@@ -42,6 +42,10 @@ export const tableDictionary: Dictionary = {
     fr: 'Information mesurée',
     en: 'Measure information',
   },
+  collectionFilter: {
+    fr: 'Filtre de collecte',
+    en: 'Collection filter',
+  },
   conditionFilter: {
     fr: 'Condition de collecte',
     en: 'Collection condition',

--- a/src/constants/dictionary/table.ts
+++ b/src/constants/dictionary/table.ts
@@ -43,7 +43,7 @@ export const tableDictionary: Dictionary = {
     en: 'Measure information',
   },
   conditionFilter: {
-    fr: 'Condition de non collecte',
-    en: 'Non-collection condition',
+    fr: 'Condition de collecte',
+    en: 'Collection condition',
   },
 };

--- a/src/model/formToState/component-new-edit/response-format-table.jsx
+++ b/src/model/formToState/component-new-edit/response-format-table.jsx
@@ -58,6 +58,7 @@ export const defaultMeasureSimpleState = {
 
 export const defaultMeasureState = {
   label: '',
+  hasFilter: false,
   conditionFilter: undefined,
   type: SIMPLE,
   [SIMPLE]: defaultMeasureSimpleState,
@@ -72,6 +73,7 @@ export const defaultMeasureState = {
 
 export const defaultMeasureForm = {
   label: '',
+  hasFilter: false,
   conditionFilter: undefined,
   type: SIMPLE,
   [SIMPLE]: defaultMeasureSimpleState,
@@ -257,6 +259,10 @@ export function stateToFormMeasure(
       [DEFAULT_CODES_LIST_SELECTOR_PATH]: codesListState,
     },
   } = currentState;
+
+  // since we do not have hasFilter in the model, we create the boolean here : true if conditionFilter has a value
+  const hasFilter = !!conditionFilter;
+
   let codesListForm;
 
   if (codesListMeasure) {
@@ -270,6 +276,7 @@ export function stateToFormMeasure(
 
   return {
     label,
+    hasFilter,
     conditionFilter,
     type,
     [SIMPLE]: simpleState,

--- a/src/model/formToState/component-new-edit/response-format-table.jsx
+++ b/src/model/formToState/component-new-edit/response-format-table.jsx
@@ -58,6 +58,7 @@ export const defaultMeasureSimpleState = {
 
 export const defaultMeasureState = {
   label: '',
+  conditionFilter: undefined,
   type: SIMPLE,
   [SIMPLE]: defaultMeasureSimpleState,
   [SINGLE_CHOICE]: {
@@ -71,6 +72,7 @@ export const defaultMeasureState = {
 
 export const defaultMeasureForm = {
   label: '',
+  conditionFilter: undefined,
   type: SIMPLE,
   [SIMPLE]: defaultMeasureSimpleState,
   [SINGLE_CHOICE]: {
@@ -152,9 +154,12 @@ export function formToStateSecondary(form, codesListSecondary) {
 }
 
 export function formToStateMeasure(form, codesListMeasure) {
-  const { label, type, [type]: measureForm } = form;
+  const { label, conditionFilter, type, [type]: measureForm } = form;
   const state = {
     label: verifyVariable(label),
+    conditionFilter: conditionFilter
+      ? verifyVariable(conditionFilter)
+      : conditionFilter,
     type,
   };
 
@@ -244,6 +249,7 @@ export function stateToFormMeasure(
 ) {
   const {
     label,
+    conditionFilter,
     type,
     [SIMPLE]: simpleState,
     [SINGLE_CHOICE]: {
@@ -264,6 +270,7 @@ export function stateToFormMeasure(
 
   return {
     label,
+    conditionFilter,
     type,
     [SIMPLE]: simpleState,
     [SINGLE_CHOICE]: {
@@ -361,10 +368,11 @@ const Factory = (initialState = {}, codesListsStore) => {
   });
   currentState[LIST_MEASURE].measures = currentState[LIST_MEASURE].measures.map(
     (m) => {
-      const { type, label, [type]: measureState } = m;
+      const { type, label, conditionFilter, [type]: measureState } = m;
       const state = {
         type,
         label,
+        conditionFilter,
       };
 
       if (type === SINGLE_CHOICE) {

--- a/src/model/transformations/response-format-table.jsx
+++ b/src/model/transformations/response-format-table.jsx
@@ -189,7 +189,7 @@ function remoteToStateSecondary(remote) {
 function remoteToStateMeasure(remote) {
   const {
     Label: label,
-    response: { CodeListReference, Datatype },
+    response: { CodeListReference, Datatype, conditionFilter },
   } = remote;
   const state = {};
 
@@ -207,7 +207,7 @@ function remoteToStateMeasure(remote) {
 
   return {
     label,
-    conditionFilter: Datatype.conditionFilter,
+    conditionFilter,
     ...state,
   };
 }

--- a/src/model/transformations/response-format-table.jsx
+++ b/src/model/transformations/response-format-table.jsx
@@ -207,6 +207,7 @@ function remoteToStateMeasure(remote) {
 
   return {
     label,
+    conditionFilter: Datatype.conditionFilter,
     ...state,
   };
 }
@@ -253,8 +254,12 @@ export function remoteToState(remote, codesListsStore) {
 // STATE TO REMOTE
 
 function stateToResponseState(state) {
-  const { type: measureType, [measureType]: measureTypeState } = state;
-  let responseState = {};
+  const {
+    type: measureType,
+    [measureType]: measureTypeState,
+    conditionFilter,
+  } = state;
+  let responseState = { conditionFilter };
 
   if (measureType === SIMPLE) {
     const {
@@ -314,7 +319,12 @@ function stateToResponseState(state) {
       customsimpleState = durationDataType;
     }
 
-    responseState = { mandatory, typeName, ...customsimpleState };
+    responseState = {
+      ...responseState,
+      mandatory,
+      typeName,
+      ...customsimpleState,
+    };
   } else {
     const {
       mandatory,
@@ -322,6 +332,7 @@ function stateToResponseState(state) {
       [DEFAULT_CODES_LIST_SELECTOR_PATH]: { id: codesListId },
     } = measureTypeState;
     responseState = {
+      ...responseState,
       mandatory,
       codesListId,
       typeName: TEXT,

--- a/src/model/transformations/response-format-table.jsx
+++ b/src/model/transformations/response-format-table.jsx
@@ -253,13 +253,18 @@ export function remoteToState(remote, codesListsStore) {
 
 // STATE TO REMOTE
 
-function stateToResponseState(state) {
+function stateToResponseState(state, primaryType) {
   const {
     type: measureType,
     [measureType]: measureTypeState,
     conditionFilter,
   } = state;
-  let responseState = { conditionFilter };
+  let responseState = {};
+
+  // we keep response conditionFilter only in dynamic tables
+  if (primaryType === 'LIST') {
+    responseState = { ...responseState, conditionFilter };
+  }
 
   if (measureType === SIMPLE) {
     const {
@@ -392,7 +397,7 @@ export function stateToRemote(
     dimensionsModel.push(
       Dimension.stateToRemote({ type: MEASURE, label: measureState.label }),
     );
-    responsesState = [stateToResponseState(measureState)];
+    responsesState = [stateToResponseState(measureState, type)];
   } else {
     for (let i = 0; i < listMeasuresState.length; i += 1) {
       dimensionsModel.push(
@@ -401,7 +406,7 @@ export function stateToRemote(
           label: listMeasuresState[i].label,
         }),
       );
-      responsesState.push(stateToResponseState(listMeasuresState[i]));
+      responsesState.push(stateToResponseState(listMeasuresState[i], type));
     }
   }
 

--- a/src/model/transformations/response-format-table.spec.jsx
+++ b/src/model/transformations/response-format-table.spec.jsx
@@ -171,6 +171,7 @@ describe('remoteToState', () => {
             type: 'TextDatatypeType',
             MaxLength: 249,
           },
+          conditionFilter: 'my condition',
           CollectedVariableReference: 'joxzq5qe',
         },
         {
@@ -262,6 +263,7 @@ describe('remoteToState', () => {
       LIST_MEASURE: [
         {
           label: 'mes1',
+          conditionFilter: 'my condition',
           type: 'SIMPLE',
           SIMPLE: {
             type: 'TEXT',
@@ -800,7 +802,7 @@ describe('remoteToState', () => {
 });
 
 describe('stateToRemote', () => {
-  it('without secondary axes', () => {
+  it('with list as primary type', () => {
     const state = {
       PRIMARY: {
         type: 'LIST',
@@ -815,12 +817,120 @@ describe('stateToRemote', () => {
       LIST_MEASURE: [
         {
           label: 'measure 1',
+          conditionFilter: 'my condition',
+          type: 'SIMPLE',
+          SIMPLE: { type: 'TEXT', TEXT: { maxLength: 249 } },
+        },
+        {
+          label: 'measure 2',
           type: 'SIMPLE',
           SIMPLE: { type: 'TEXT', TEXT: { maxLength: 249 } },
         },
       ],
     };
     const collectedVariables = ['jf0v461m', 'jf0v6ywk'];
+    const collectedVariablesStore = {
+      jf0v461m: {
+        id: 'jf0v461m',
+        name: 'QUESTION11',
+        label: 'Line1-measure 1',
+        x: 1,
+        y: 1,
+        type: 'TEXT',
+        TEXT: { maxLength: 249 },
+        NUMERIC: { maximum: '', minimum: '', decimals: '' },
+        DURATION: { maximum: '', minimum: '', format: '' },
+        DATE: { maximum: '', minimum: '', format: '' },
+        BOOLEAN: {},
+        isCollected: '1',
+        codeListReference: '',
+        codeListReferenceLabel: '',
+      },
+      jf0v6ywk: {
+        id: 'jf0v6ywk',
+        name: 'QUESTION21',
+        label: 'Line2-measure 1',
+        x: 1,
+        y: 2,
+        type: 'TEXT',
+        TEXT: { maxLength: 249 },
+        NUMERIC: { maximum: '', minimum: '', decimals: '' },
+        DURATION: { maximum: '', minimum: '', format: '' },
+        DATE: { maximum: '', minimum: '', format: '' },
+        BOOLEAN: {},
+        isCollected: '1',
+        codeListReference: '',
+        codeListReferenceLabel: '',
+      },
+    };
+    const result = stateToRemote(
+      state,
+      collectedVariables,
+      collectedVariablesStore,
+    );
+
+    expect(result.Dimension).toEqual([
+      {
+        dimensionType: 'PRIMARY',
+        dynamic: 'DYNAMIC_LENGTH',
+        MinLines: 2,
+        MaxLines: 3,
+      },
+      {
+        Label: 'measure 1',
+        dimensionType: 'MEASURE',
+      },
+      {
+        Label: 'measure 2',
+        dimensionType: 'MEASURE',
+      },
+    ]);
+
+    expect(result.Attribute).toEqual([]);
+
+    const outputMapping = result.Mapping;
+    const outputResponse = result.Response;
+
+    expect(outputMapping.length).toEqual(outputResponse.length);
+    expect(outputResponse[0].conditionFilter).toEqual('my condition');
+    expect(outputResponse[1].conditionFilter).toBeUndefined();
+    expect(outputResponse[0].Datatype).toEqual({
+      MaxLength: 249,
+
+      type: 'TextDatatypeType',
+      typeName: 'TEXT',
+    });
+    expect(outputResponse[1].Datatype).toEqual({
+      MaxLength: 249,
+
+      type: 'TextDatatypeType',
+      typeName: 'TEXT',
+    });
+    expect(outputMapping[0].MappingTarget).toEqual('1 1');
+    expect(outputMapping[1].MappingTarget).toEqual('1 2');
+  });
+
+  it('with code list as primary type, without secondary axes', () => {
+    const state = {
+      PRIMARY: {
+        type: 'CODES_LIST',
+        CODES_LIST: { CodesList: { id: 'jf0vbzj9' } },
+      },
+      LIST_MEASURE: [
+        {
+          label: 'measure 1',
+          conditionFilter: 'my condition',
+          type: 'SIMPLE',
+          SIMPLE: { type: 'TEXT', TEXT: { maxLength: 249 } },
+        },
+        {
+          label: 'measure 2',
+          type: 'SIMPLE',
+          SIMPLE: { type: 'TEXT', TEXT: { maxLength: 249 } },
+        },
+      ],
+    };
+    const collectedVariables = ['jf0v461m', 'jf0v6ywk', 'jg4v561m', 'jk8h32gm'];
     const collectedVariablesStore = {
       jf0v461m: {
         id: 'jf0v461m',
@@ -854,6 +964,38 @@ describe('stateToRemote', () => {
         codeListReference: '',
         codeListReferenceLabel: '',
       },
+      jg4v561m: {
+        id: 'jg4v561m',
+        name: 'QUESTION12',
+        label: 'Line1-measure 2',
+        x: 1,
+        y: 2,
+        type: 'TEXT',
+        TEXT: { maxLength: 249 },
+        NUMERIC: { maximum: '', minimum: '', decimals: '' },
+        DURATION: { maximum: '', minimum: '', format: '' },
+        DATE: { maximum: '', minimum: '', format: '' },
+        BOOLEAN: {},
+        isCollected: '0',
+        codeListReference: '',
+        codeListReferenceLabel: '',
+      },
+      jk8h32gm: {
+        id: 'jk8h32gm',
+        name: 'QUESTION22',
+        label: 'Line2-measure 2',
+        x: 2,
+        y: 2,
+        type: 'TEXT',
+        TEXT: { maxLength: 249 },
+        NUMERIC: { maximum: '', minimum: '', decimals: '' },
+        DURATION: { maximum: '', minimum: '', format: '' },
+        DATE: { maximum: '', minimum: '', format: '' },
+        BOOLEAN: {},
+        isCollected: '0',
+        codeListReference: '',
+        codeListReferenceLabel: '',
+      },
     };
     const result = stateToRemote(
       state,
@@ -863,13 +1005,16 @@ describe('stateToRemote', () => {
 
     expect(result.Dimension).toEqual([
       {
+        CodeListReference: 'jf0vbzj9',
         dimensionType: 'PRIMARY',
-        dynamic: 'DYNAMIC_LENGTH',
-        MinLines: 2,
-        MaxLines: 3,
+        dynamic: 'NON_DYNAMIC',
       },
       {
         Label: 'measure 1',
+        dimensionType: 'MEASURE',
+      },
+      {
+        Label: 'measure 2',
         dimensionType: 'MEASURE',
       },
     ]);
@@ -883,15 +1028,26 @@ describe('stateToRemote', () => {
         AttributeValue: 'NoDataByDefinition',
         AttributeTarget: '2 1',
       },
+      {
+        AttributeTarget: '1 2',
+        AttributeValue: 'NoDataByDefinition',
+      },
+      {
+        AttributeTarget: '2 2',
+        AttributeValue: 'NoDataByDefinition',
+      },
     ]);
 
     const outputMapping = result.Mapping;
     const outputResponse = result.Response;
 
     expect(outputMapping.length).toEqual(outputResponse.length);
+    expect(outputResponse[0].conditionFilter).toEqual('my condition');
+    expect(outputResponse[1].conditionFilter).toEqual('my condition');
+    expect(outputResponse[2].conditionFilter).toBeUndefined();
+    expect(outputResponse[3].conditionFilter).toBeUndefined();
     expect(outputResponse[0].Datatype).toEqual({
       MaxLength: 249,
-
       type: 'TextDatatypeType',
       typeName: 'TEXT',
     });
@@ -905,7 +1061,7 @@ describe('stateToRemote', () => {
     expect(outputMapping[1].MappingTarget).toEqual('2 1');
   });
 
-  it('with secondary axes', () => {
+  it('with code list as primary type, with secondary axes', () => {
     const state = {
       PRIMARY: {
         type: 'CODES_LIST',

--- a/src/model/transformations/response-format-table.spec.jsx
+++ b/src/model/transformations/response-format-table.spec.jsx
@@ -1042,10 +1042,12 @@ describe('stateToRemote', () => {
     const outputResponse = result.Response;
 
     expect(outputMapping.length).toEqual(outputResponse.length);
-    expect(outputResponse[0].conditionFilter).toEqual('my condition');
-    expect(outputResponse[1].conditionFilter).toEqual('my condition');
-    expect(outputResponse[2].conditionFilter).toBeUndefined();
-    expect(outputResponse[3].conditionFilter).toBeUndefined();
+
+    // conditionFilter is saved only for table with list as primary type
+    outputResponse.forEach((item) => {
+      expect(item.conditionFilter).toBeUndefined();
+    });
+
     expect(outputResponse[0].Datatype).toEqual({
       MaxLength: 249,
       type: 'TextDatatypeType',

--- a/src/model/transformations/response.ts
+++ b/src/model/transformations/response.ts
@@ -38,6 +38,7 @@ export function stateToRemote(
     allowArbitraryResponse,
     visHint: visualizationHint,
     collectedVariable: CollectedVariableReference,
+    conditionFilter,
   } = state;
 
   const find = response
@@ -84,6 +85,8 @@ export function stateToRemote(
   if (Maminutes !== undefined) model.Datatype.Maminutes = Maminutes;
   if (Mayears !== undefined) model.Datatype.Mayears = Mayears;
   if (Mamonths !== undefined) model.Datatype.Mamonths = Mamonths;
+  if (conditionFilter !== undefined)
+    model.Datatype.conditionFilter = conditionFilter;
 
   return model;
 }

--- a/src/model/transformations/response.ts
+++ b/src/model/transformations/response.ts
@@ -85,8 +85,7 @@ export function stateToRemote(
   if (Maminutes !== undefined) model.Datatype.Maminutes = Maminutes;
   if (Mayears !== undefined) model.Datatype.Mayears = Mayears;
   if (Mamonths !== undefined) model.Datatype.Mamonths = Mamonths;
-  if (conditionFilter !== undefined)
-    model.Datatype.conditionFilter = conditionFilter;
+  if (conditionFilter !== undefined) model.conditionFilter = conditionFilter;
 
   return model;
 }

--- a/src/model/transformations/types.ts
+++ b/src/model/transformations/types.ts
@@ -27,6 +27,7 @@ export type StateResponse = {
   allowArbitraryResponse?: unknown;
   visHint?: unknown;
   collectedVariable?: string;
+  conditionFilter?: string;
 };
 
 export type RemoteResponse = {
@@ -55,4 +56,5 @@ export type RemoteResponse = {
   CollectedVariableReference?: string;
   CodeListReference?: unknown;
   mandatory?: unknown;
+  conditionFilter?: string;
 };

--- a/src/widgets/component-new-edit/components/response-format/table/input-measure.jsx
+++ b/src/widgets/component-new-edit/components/response-format/table/input-measure.jsx
@@ -1,10 +1,13 @@
 import React from 'react';
 
 import PropTypes from 'prop-types';
-import { Field } from 'redux-form';
+import { connect } from 'react-redux';
+import { Field, change, formValueSelector } from 'redux-form';
 
 import { QUESTION_TYPE_ENUM } from '../../../../../constants/pogues-constants';
 import { RichEditorWithVariable } from '../../../../../forms/controls/control-with-suggestions';
+import GenericOption from '../../../../../forms/controls/generic-option';
+import ListRadios from '../../../../../forms/controls/list-radios';
 import { toolbarConfigTooltip } from '../../../../../forms/controls/rich-textarea';
 import Dictionary from '../../../../../utils/dictionary/dictionary';
 import { SelectorView, View } from '../../../../selector-view';
@@ -13,7 +16,16 @@ import ResponseFormatSingle from '../single/response-format-single';
 
 const { SIMPLE, SINGLE_CHOICE } = QUESTION_TYPE_ENUM;
 
-function InputMeasure({ selectorPath, disableSetConditionFilter = false }) {
+function InputMeasure({
+  selectorPath,
+  disableSetConditionFilter = false,
+  hasFilter,
+  setConditionFilter,
+}) {
+  const handleFilterChange = () => {
+    setConditionFilter(undefined);
+  };
+
   return (
     <div>
       <Field
@@ -49,12 +61,31 @@ function InputMeasure({ selectorPath, disableSetConditionFilter = false }) {
         </View>
       </SelectorView>
       {!disableSetConditionFilter && (
-        <Field
-          name="conditionFilter"
-          component={RichEditorWithVariable}
-          label={Dictionary.conditionFilter}
-          toolbar={toolbarConfigTooltip}
-        />
+        <>
+          <Field
+            name="hasFilter"
+            component={ListRadios}
+            label={Dictionary.collectionFilter}
+            required
+            // Reset condition filter to undefined value on change
+            onChange={handleFilterChange}
+            // Convert string "true"/"false" to boolean true/false when storing in Redux form
+            parse={(value) => value === 'true'}
+            // Convert true/false/undefined to string "true"/"false" when displaying the form
+            format={(value) => (value === true ? 'true' : 'false')}
+          >
+            <GenericOption value="true">{Dictionary.yes}</GenericOption>
+            <GenericOption value="false">{Dictionary.no}</GenericOption>
+          </Field>
+          {hasFilter && (
+            <Field
+              name="conditionFilter"
+              component={RichEditorWithVariable}
+              label={Dictionary.conditionFilter}
+              toolbar={toolbarConfigTooltip}
+            />
+          )}
+        </>
       )}
     </div>
   );
@@ -63,6 +94,23 @@ function InputMeasure({ selectorPath, disableSetConditionFilter = false }) {
 InputMeasure.propTypes = {
   selectorPath: PropTypes.string.isRequired,
   disableSetConditionFilter: PropTypes.bool,
+  hasFilter: PropTypes.bool,
+  setConditionFilter: PropTypes.func,
 };
 
-export default InputMeasure;
+// Container
+const mapStateToProps = (state, { selectorPath }) => {
+  const selector = formValueSelector('component');
+  return {
+    hasFilter: selector(state, `${selectorPath}.hasFilter`),
+    conditionFilter: selector(state, `${selectorPath}.conditionFilter`),
+  };
+};
+
+// Dispatch actions to change form values
+const mapDispatchToProps = (dispatch, { selectorPath }) => ({
+  setConditionFilter: (value) =>
+    dispatch(change('component', `${selectorPath}.conditionFilter`, value)),
+});
+
+export default connect(mapStateToProps, mapDispatchToProps)(InputMeasure);

--- a/src/widgets/component-new-edit/components/response-format/table/input-measure.jsx
+++ b/src/widgets/component-new-edit/components/response-format/table/input-measure.jsx
@@ -13,7 +13,7 @@ import ResponseFormatSingle from '../single/response-format-single';
 
 const { SIMPLE, SINGLE_CHOICE } = QUESTION_TYPE_ENUM;
 
-function InputMeasure({ selectorPath }) {
+function InputMeasure({ selectorPath, disableSetConditionFilter = false }) {
   return (
     <div>
       <Field
@@ -23,12 +23,14 @@ function InputMeasure({ selectorPath }) {
         toolbar={toolbarConfigTooltip}
         required
       />
-      <Field
-        name="conditionFilter"
-        component={RichEditorWithVariable}
-        label={Dictionary.conditionFilter}
-        toolbar={toolbarConfigTooltip}
-      />
+      {!disableSetConditionFilter && (
+        <Field
+          name="conditionFilter"
+          component={RichEditorWithVariable}
+          label={Dictionary.conditionFilter}
+          toolbar={toolbarConfigTooltip}
+        />
+      )}
       <SelectorView label={Dictionary.typeMeasure} selectorPath={selectorPath}>
         <View
           key={SIMPLE}
@@ -60,6 +62,7 @@ function InputMeasure({ selectorPath }) {
 
 InputMeasure.propTypes = {
   selectorPath: PropTypes.string.isRequired,
+  disableSetConditionFilter: PropTypes.bool,
 };
 
 export default InputMeasure;

--- a/src/widgets/component-new-edit/components/response-format/table/input-measure.jsx
+++ b/src/widgets/component-new-edit/components/response-format/table/input-measure.jsx
@@ -23,14 +23,6 @@ function InputMeasure({ selectorPath, disableSetConditionFilter = false }) {
         toolbar={toolbarConfigTooltip}
         required
       />
-      {!disableSetConditionFilter && (
-        <Field
-          name="conditionFilter"
-          component={RichEditorWithVariable}
-          label={Dictionary.conditionFilter}
-          toolbar={toolbarConfigTooltip}
-        />
-      )}
       <SelectorView label={Dictionary.typeMeasure} selectorPath={selectorPath}>
         <View
           key={SIMPLE}
@@ -56,6 +48,14 @@ function InputMeasure({ selectorPath, disableSetConditionFilter = false }) {
           />
         </View>
       </SelectorView>
+      {!disableSetConditionFilter && (
+        <Field
+          name="conditionFilter"
+          component={RichEditorWithVariable}
+          label={Dictionary.conditionFilter}
+          toolbar={toolbarConfigTooltip}
+        />
+      )}
     </div>
   );
 }

--- a/src/widgets/component-new-edit/components/response-format/table/input-measure.jsx
+++ b/src/widgets/component-new-edit/components/response-format/table/input-measure.jsx
@@ -23,7 +23,12 @@ function InputMeasure({ selectorPath }) {
         toolbar={toolbarConfigTooltip}
         required
       />
-
+      <Field
+        name="conditionFilter"
+        component={RichEditorWithVariable}
+        label={Dictionary.conditionFilter}
+        toolbar={toolbarConfigTooltip}
+      />
       <SelectorView label={Dictionary.typeMeasure} selectorPath={selectorPath}>
         <View
           key={SIMPLE}

--- a/src/widgets/component-new-edit/components/response-format/table/response-format-table.jsx
+++ b/src/widgets/component-new-edit/components/response-format/table/response-format-table.jsx
@@ -49,9 +49,13 @@ function ResponseFormatTable({
         <TableListMeasures
           selectorPath={`${selectorPathComposed}.LIST_MEASURE`}
           addErrors={addErrors}
+          disableSetConditionFilter={primaryAxisType === CODES_LIST}
         />
       ) : (
-        <ResponseFormatTableMeasure selectorPathParent={selectorPathComposed} />
+        <ResponseFormatTableMeasure
+          selectorPathParent={selectorPathComposed}
+          disableSetConditionFilter={true}
+        />
       )}
     </FormSection>
   );

--- a/src/widgets/component-new-edit/components/response-format/table/table-list-measures.jsx
+++ b/src/widgets/component-new-edit/components/response-format/table/table-list-measures.jsx
@@ -13,7 +13,12 @@ const validateForm = (addErrors, validate) => (values) => {
   return validate(values, addErrors);
 };
 
-function TableListMeasures({ formName, selectorPath, addErrors }) {
+function TableListMeasures({
+  formName,
+  selectorPath,
+  addErrors,
+  disableSetConditionFilter,
+}) {
   return (
     <FormSection name="LIST_MEASURE">
       <ListWithInputPanel
@@ -23,7 +28,10 @@ function TableListMeasures({ formName, selectorPath, addErrors }) {
         validateForm={validateForm(addErrors, validateTableListMeasuresForm)}
         resetObject={defaultMeasureState}
       >
-        <InputMeasure selectorPath={selectorPath} />
+        <InputMeasure
+          selectorPath={selectorPath}
+          disableSetConditionFilter={disableSetConditionFilter}
+        />
       </ListWithInputPanel>
     </FormSection>
   );
@@ -33,6 +41,7 @@ TableListMeasures.propTypes = {
   formName: PropTypes.string,
   selectorPath: PropTypes.string.isRequired,
   addErrors: PropTypes.func.isRequired,
+  disableSetConditionFilter: PropTypes.bool,
 };
 
 TableListMeasures.defaultProps = {

--- a/src/widgets/component-new-edit/components/response-format/table/table-measure.jsx
+++ b/src/widgets/component-new-edit/components/response-format/table/table-measure.jsx
@@ -8,20 +8,27 @@ import InputMeasure from './input-measure';
 
 const { MEASURE: selectorPath } = DIMENSION_TYPE;
 
-function ResponseFormatTableMeasure({ selectorPathParent }) {
+function ResponseFormatTableMeasure({
+  selectorPathParent,
+  disableSetConditionFilter,
+}) {
   const selectorPathComposed = selectorPathParent
     ? `${selectorPathParent}.${selectorPath}`
     : selectorPath;
 
   return (
     <FormSection name={selectorPath}>
-      <InputMeasure selectorPath={selectorPathComposed} />
+      <InputMeasure
+        selectorPath={selectorPathComposed}
+        disableSetConditionFilter={disableSetConditionFilter}
+      />
     </FormSection>
   );
 }
 
 ResponseFormatTableMeasure.propTypes = {
   selectorPathParent: PropTypes.string,
+  disableSetConditionFilter: PropTypes.bool,
 };
 
 ResponseFormatTableMeasure.defaultProps = {


### PR DESCRIPTION
In dynamic table only (table with type = 'List'), when defining measures, add a VTL field for defining a condition of filter.

In term of model, in the response, add a new prop :
`"conditionFilter": "the condition formula i want"`

nb : we named it "conditionFilter" to be coherent with the rest of our app, even if would be more logical to call it "filterCondition"