### PR TITLE
fix: refresh codesLists list when duplicate/delete a codeList

### DIFF
--- a/next/src/api/codesLists.ts
+++ b/next/src/api/codesLists.ts
@@ -23,7 +23,7 @@ export type CodeListRelatedQuestionError = {
  */
 export const codesListsQueryOptions = (questionnaireId: string) =>
   queryOptions({
-    queryKey: ['codeslists', { questionnaireId }],
+    queryKey: ['codesLists', { questionnaireId }],
     queryFn: () => getCodesLists(questionnaireId),
   });
 

--- a/next/src/components/codesLists/overview/CodesListOverviewItem.tsx
+++ b/next/src/components/codesLists/overview/CodesListOverviewItem.tsx
@@ -54,7 +54,7 @@ export default function CodesListOverviewItem({
     },
     onSuccess: (_, { questionnaireId }) =>
       queryClient.invalidateQueries({
-        queryKey: ['questionnaire', { questionnaireId }],
+        queryKey: ['codesLists', { questionnaireId }],
       }),
   });
 
@@ -70,7 +70,7 @@ export default function CodesListOverviewItem({
     },
     onSuccess: (_, { questionnaireId }) =>
       queryClient.invalidateQueries({
-        queryKey: ['questionnaire', { questionnaireId }],
+        queryKey: ['codesLists', { questionnaireId }],
       }),
   });
 


### PR DESCRIPTION
Refresh correctly the list of codesLists when we duplicate or delete one.

Nb: we just invalidate query, so we do not lose current filters