### PR TITLE
fix: edit multiple codes simultaneously

### DIFF
--- a/next/src/components/codesLists/form/CodesListForm.tsx
+++ b/next/src/components/codesLists/form/CodesListForm.tsx
@@ -274,6 +274,7 @@ function CodesField({
         render={({ field, fieldState: { error } }) =>
           formulasLanguage === FormulasLanguages.VTL ? (
             <VTLEditor
+              key={`${namePrefix}.label`}
               data-testid={`${namePrefix}.label`}
               className="col-start-2 h-20"
               suggestionsVariables={variables}


### PR DESCRIPTION
When editing a codesList, if you remove a code, then when updating the label of another code it updates simultaneously the label of multiple codes.
Only hapening with VTL editor (no problem with xpath questionnaire that replaces editor by an input).

---

For Input there is no problem since the name is given to the input, it handles it well when the number of fields changes after deleting an item.
VTL Editor (AntlrEditor) does not handle name, so the only way to refresh it correctly is to force a key.