### PR TITLE
feat: disable mandatory for suggester

### DIFF
--- a/src/model/formToState/component-new-edit/response-format-single.jsx
+++ b/src/model/formToState/component-new-edit/response-format-single.jsx
@@ -7,7 +7,7 @@ import {
   DEFAULT_CODES_LIST_SELECTOR_PATH,
 } from '../../../constants/pogues-constants';
 
-const { RADIO } = DATATYPE_VIS_HINT;
+const { RADIO, SUGGESTER } = DATATYPE_VIS_HINT;
 
 export const defaultState = {
   allowArbitraryResponse: false,
@@ -35,7 +35,8 @@ export function formToState(form, transformers) {
   return {
     id,
     allowArbitraryResponse,
-    mandatory,
+    // for suggester we do not handle mandatory question
+    mandatory: visHint !== SUGGESTER ? mandatory : false,
     visHint,
     [DEFAULT_CODES_LIST_SELECTOR_PATH]:
       transformers.codesList.formToStateComponent(codesListForm),

--- a/src/widgets/component-new-edit/components/response-format/single/response-format-single.jsx
+++ b/src/widgets/component-new-edit/components/response-format/single/response-format-single.jsx
@@ -139,17 +139,6 @@ function ResponseFormatSingle({
         </Field>
       ) : (
         <>
-          <div className="ctrl-checkbox" style={styleMandatory}>
-            <label htmlFor="rf-single-mandatory">{Dictionary.mandatory}</label>
-            <div>
-              <Field
-                name="mandatory"
-                id="rf-single-mandatory"
-                component="input"
-                type="checkbox"
-              />
-            </div>
-          </div>
           <Field
             name="visHint"
             component={ListRadios}
@@ -169,6 +158,21 @@ function ResponseFormatSingle({
               {Dictionary.suggester}
             </GenericOption>
           </Field>
+          {visHint !== SUGGESTER && (
+            <div className="ctrl-checkbox" style={styleMandatory}>
+              <label htmlFor="rf-single-mandatory">
+                {Dictionary.mandatory}
+              </label>
+              <div>
+                <Field
+                  name="mandatory"
+                  id="rf-single-mandatory"
+                  component="input"
+                  type="checkbox"
+                />
+              </div>
+            </div>
+          )}
         </>
       )}
       {visHint === SUGGESTER ? (


### PR DESCRIPTION
Currently in a single choice question, you can set the question as mandatory.
We don't want to enable it for suggester (keeping it for boolean, dropdown, checkbox).

Since currently you chose mandatory before chosing the type (suggester, ...), we reorder the fields for chosing it after, then don't display "mandatory" field for suggester.

Nb : needed to handle following case : User set for example "boolean + mandatory=true" before changing to "suggester" => do not save mandatory=true