### PR TITLE
fix: refresh codesList form values when it has been updated

### DIFF
--- a/next/src/components/codesLists/form/CodesListForm.tsx
+++ b/next/src/components/codesLists/form/CodesListForm.tsx
@@ -48,7 +48,7 @@ const baseCodeSchema = z.object({
 });
 
 type ZCodeSchema = z.infer<typeof baseCodeSchema> & {
-  codes: ZCodeSchema[];
+  codes?: ZCodeSchema[];
 };
 
 const codesSchema: z.ZodType<ZCodeSchema> = baseCodeSchema.extend({
@@ -95,7 +95,11 @@ export default function CodesListForm({
     trigger,
   } = useForm<FormValues>({
     mode: 'onChange',
-    defaultValues: codesList,
+    defaultValues: {
+      label: '',
+      codes: [{ label: '', value: '', codes: [] }],
+    },
+    values: codesList,
     resolver: zodResolver(schema),
   });
 


### PR DESCRIPTION
When updating a codesList somewhere else than in its editing form (hapening for example when we rallback to a previous questionnaire version), then when coming back on the editing form the values in the form were not updated since the form displayed the values before refetching.