### PR TITLE
fix: could not validate required field with value 0

### DIFF
--- a/src/forms/validation-rules.jsx
+++ b/src/forms/validation-rules.jsx
@@ -15,13 +15,27 @@ const { NUMERIC } = DATATYPE_NAME;
 const { SINGLE_CHOICE, SIMPLE, TABLE, MULTIPLE_CHOICE, PAIRING } =
   QUESTION_TYPE_ENUM;
 
+/**
+ * Validates that a form field has a meaningful, non-empty value.
+ *
+ * It returns an error message if the value is:
+ *  - `null` or `undefined`
+ *  - An empty string, or a string that contains only special characters or whitespace
+ *
+ * It accepts `0`, `false`, and other falsy but valid inputs.
+ */
 export function required(value = '') {
-  const val = value.trim ? value.trim().replace(/[^\w\s]/gi, '') : value;
-
-  if (typeof val === 'string' || val instanceof String) {
-    return val.length > 0 ? undefined : Dictionary.validationRequired;
+  if (value === null || value === undefined) {
+    return Dictionary.validationRequired;
   }
-  return val ? undefined : Dictionary.validationRequired;
+
+  if (typeof value === 'string') {
+    // we clean the string to ensure this is not a fake non empty string (for example ' ')
+    const cleanedValue = value.trim().replace(/[^\w\s]/gi, '');
+    return cleanedValue === '' ? Dictionary.validationRequired : undefined;
+  }
+
+  return undefined;
 }
 
 export function maxLength(max) {

--- a/src/forms/validation-rules.spec.jsx
+++ b/src/forms/validation-rules.spec.jsx
@@ -13,11 +13,28 @@ import {
   minimumRequired,
   name,
   nameSize,
+  required,
   requiredSelect,
   validCollectedVariables,
   validateDuplicates,
   validateExistingTarget,
 } from './validation-rules';
+
+describe('required', () => {
+  it('should return required field message if value is null or undefined', () => {
+    expect(required(null)).toEqual(Dictionary.validationRequired);
+    expect(required(undefined)).toEqual(Dictionary.validationRequired);
+  });
+  it('should handle string value, returning required field message only if empty string', () => {
+    expect(required('')).toEqual(Dictionary.validationRequired);
+    expect(required('my value')).toBeUndefined();
+  });
+  it('should accept numeric value', () => {
+    expect(required(2)).toBeUndefined();
+    expect(required(-2)).toBeUndefined();
+    expect(required(0)).toBeUndefined();
+  });
+});
 
 describe('maxLength', () => {
   const max = 5;


### PR DESCRIPTION
When a field was required, the validation was impossible (considering there is no value) when the value was 0.

due to direct comparison `value ?` , with 0 that is considered as a falsy value