### PR TITLE
feat(next): improve navbar responsiveness

### DIFF
--- a/next/src/components/codesLists/overview/CodesListOverviewItemDetails.tsx
+++ b/next/src/components/codesLists/overview/CodesListOverviewItemDetails.tsx
@@ -84,9 +84,7 @@ export default function CodesListOverviewItemDetails({
     });
     toast.promise(promise, {
       loading: t('common.loading'),
-      success: t('codesList.overview.duplicateSuccess', {
-        label: codesList.label,
-      }),
+      success: t('codesList.duplicate.success', { label: codesList.label }),
       error: (err: Error) => err.toString(),
     });
   }
@@ -98,16 +96,14 @@ export default function CodesListOverviewItemDetails({
     });
     toast.promise(promise, {
       loading: t('common.loading'),
-      success: t('codesList.overview.deleteSuccess', {
-        label: codesList.label,
-      }),
+      success: t('codesList.delete.success', { label: codesList.label }),
       error: (err: AxiosError<CodeListError>) => {
         if (
           err.response?.data.errorCode === ERROR_CODES.RELATED_QUESTION_NAMES
         ) {
           const { relatedQuestionNames } = err.response
             .data as CodeListRelatedQuestionError;
-          return t('codesList.overview.deleteError.usedByQuestions', {
+          return t('codesList.delete.error.usedByQuestions', {
             questions: relatedQuestionNames.join('\n'),
           });
         }
@@ -130,23 +126,23 @@ export default function CodesListOverviewItemDetails({
             {t('common.edit')}
           </ButtonLink>
           <Dialog
-            label={t('codesList.overview.duplicate')}
-            title={t('codesList.overview.duplicateDialogTitle', {
+            label={t('codesList.duplicate.label')}
+            title={t('codesList.duplicate.dialogTitle', {
               label: codesList.label,
             })}
-            body={t('codesList.overview.duplicateDialogConfirm')}
+            body={t('codesList.duplicate.dialogConfirm')}
             onValidate={onDuplicate}
           />
           <Dialog
             label={t('common.delete')}
-            title={t('codesList.overview.deleteDialogTitle', {
+            title={t('codesList.delete.dialogTitle', {
               label: codesList.label,
             })}
-            body={t('codesList.overview.deleteDialogConfirm')}
+            body={t('codesList.delete.dialogConfirm')}
             onValidate={onDelete}
             buttonTitle={
               hasRelatedQuestion
-                ? t('codesList.overview.deleteDisabled.usedByQuestions')
+                ? t('codesList.delete.disabled.usedByQuestions')
                 : undefined
             }
             disabled={hasRelatedQuestion}

--- a/next/src/components/codesLists/overview/CodesListsOverview.test.tsx
+++ b/next/src/components/codesLists/overview/CodesListsOverview.test.tsx
@@ -43,7 +43,7 @@ describe('CodesListOverview', () => {
       ),
     );
 
-    expect(getAllByText('Create a code list')).toHaveLength(1);
+    expect(getAllByText('Create a codes list')).toHaveLength(1);
   });
 
   it('filters the code lists based on the search input', async () => {

--- a/next/src/components/codesLists/overview/CodesListsOverview.tsx
+++ b/next/src/components/codesLists/overview/CodesListsOverview.tsx
@@ -58,8 +58,8 @@ export default function CodesListsOverview({
     <>
       <div>
         <Input
-          label={t('codesList.overview.search')}
-          placeholder={t('codesList.overview.search')}
+          label={t('codesLists.search')}
+          placeholder={t('codesLists.search')}
           value={searchFilterContent}
           onChange={(e) =>
             updateFilterContent(FilterEnum.Search, e.target.value)
@@ -90,7 +90,7 @@ export default function CodesListsOverview({
       params={{ questionnaireId }}
       buttonStyle={ButtonStyle.Primary}
     >
-      {t('codesList.overview.create')}
+      {t('codesLists.create')}
     </ButtonLink>
   );
 }

--- a/next/src/components/layout/NavigationBar.tsx
+++ b/next/src/components/layout/NavigationBar.tsx
@@ -3,12 +3,14 @@ import { Link, useMatchRoute } from '@tanstack/react-router';
 import NavigationBarItem from './NavigationBarItem';
 
 export type NavigationItem = {
-  label: string;
-  icon: React.JSX.Element | null;
-  path: string;
+  Icon: React.FC<React.ComponentProps<'svg'>>;
+  iconClassName?: string;
   innerPaths?: string[];
   isDisabled?: boolean;
   isHidden?: boolean;
+  label: string;
+  onIconClick?: () => void;
+  path: string;
 };
 
 interface NavigationBarProps {
@@ -27,7 +29,16 @@ export default function NavigationBar({
     <nav>
       <ul>
         {navigationItems.map(
-          ({ label, icon, isDisabled, path, innerPaths = [], isHidden }) =>
+          ({
+            label,
+            Icon,
+            iconClassName,
+            isDisabled,
+            onIconClick,
+            path,
+            innerPaths = [],
+            isHidden,
+          }) =>
             !isHidden ? (
               <li key={label}>
                 <Link
@@ -37,8 +48,10 @@ export default function NavigationBar({
                   className={`w-full aria-disabled:opacity-25 aria-disabled:pointer-events-none`}
                 >
                   <NavigationBarItem
-                    icon={icon}
+                    Icon={Icon}
+                    iconClassName={iconClassName}
                     label={label}
+                    onIconClick={onIconClick}
                     active={
                       !!matchRoute({ to: path }) ||
                       innerPaths.some((path) => !!matchRoute({ to: path }))

--- a/next/src/components/layout/NavigationBarItem.test.tsx
+++ b/next/src/components/layout/NavigationBarItem.test.tsx
@@ -7,7 +7,7 @@ describe('NavigationBarItem', () => {
   it('display label', () => {
     const { getByText } = render(
       <NavigationBarItem
-        icon={null}
+        Icon={() => <svg />}
         label="my navigation item"
         active={false}
       />,
@@ -18,7 +18,11 @@ describe('NavigationBarItem', () => {
 
   it('is accessible when active', () => {
     const { getByText } = render(
-      <NavigationBarItem icon={null} label="my navigation item" active />,
+      <NavigationBarItem
+        Icon={() => <svg />}
+        label="my navigation item"
+        active
+      />,
     );
 
     expect(getByText(/my navigation item/i).parentElement).toHaveAttribute(

--- a/next/src/components/layout/NavigationBarItem.tsx
+++ b/next/src/components/layout/NavigationBarItem.tsx
@@ -1,21 +1,29 @@
 interface NavigationBarItemProps {
-  icon: React.JSX.Element | null;
-  label: string;
   active?: boolean;
+  Icon: React.FC<React.ComponentProps<'svg'>>;
+  iconClassName?: string;
+  label: string;
+  onIconClick?: () => void;
 }
 
 export default function NavigationBarItem({
-  icon,
-  label,
   active = false,
+  Icon,
+  iconClassName = '',
+  label,
+  onIconClick,
 }: Readonly<NavigationBarItemProps>) {
   return (
     <div
       aria-current={active}
-      className="grid grid-cols-[auto_1fr] items-center p-2 gap-x-3 cursor-pointer hover:text-blue-600 hover:fill-blue-600 hover:bg-blue-50 aria-current:text-blue-600 aria-current:fill-blue-600 aria-current:hover:bg-blue-200 aria-current:bg-blue-200 disabled:bg-disabled"
+      className="2xl:grid 2xl:grid-cols-[auto_1fr] items-center p-2 gap-x-3 cursor-pointer hover:text-blue-600 hover:fill-blue-600 hover:bg-blue-50 aria-current:text-blue-600 aria-current:fill-blue-600 aria-current:hover:bg-blue-200 aria-current:bg-blue-200 disabled:bg-disabled"
+      title={label}
     >
-      {icon}
-      <span>{label}</span>
+      <Icon
+        className={`m-auto size-8 2xl:size-6 ${iconClassName}`}
+        onClick={onIconClick}
+      />
+      <span className="hidden 2xl:inline">{label}</span>
     </div>
   );
 }

--- a/next/src/components/layout/QuestionnaireNavigation.test.tsx
+++ b/next/src/components/layout/QuestionnaireNavigation.test.tsx
@@ -11,8 +11,8 @@ describe('QuestionnaireNavigation', () => {
       renderWithRouter(<QuestionnaireNavigation />),
     );
 
-    expect(getByText(/Overview/i)).toBeInTheDocument();
-    expect(getByText(/Code lists/i)).toBeInTheDocument();
+    expect(getByText(/Questionnaire/i)).toBeInTheDocument();
+    expect(getByText(/Codes lists/i)).toBeInTheDocument();
     expect(getByText(/Nomenclatures/i)).toBeInTheDocument();
     expect(getByText(/History/i)).toBeInTheDocument();
   });

--- a/next/src/components/layout/QuestionnaireNavigation.tsx
+++ b/next/src/components/layout/QuestionnaireNavigation.tsx
@@ -25,21 +25,21 @@ export default function QuestionnaireNavigation() {
   /** Navigation items that change with the version. */
   const questionnaireVersionItems: NavigationItem[] = [
     {
-      label: t('questionnaires.navigation.overview'),
+      label: t('questionnaire.title'),
       Icon: DashboardIcon,
       path: versionId
         ? `/questionnaire/$questionnaireId/version/$versionId`
         : '/questionnaire/$questionnaireId',
     },
     {
-      label: t('questionnaires.navigation.variables'),
+      label: t('variables.title'),
       Icon: VariableIcon,
       path: '/',
       isDisabled: true,
       isHidden: true,
     },
     {
-      label: t('questionnaires.navigation.codeLists'),
+      label: t('codesLists.title'),
       Icon: ListIcon,
       path: versionId
         ? `/questionnaire/$questionnaireId/version/$versionId/codes-lists`
@@ -50,14 +50,14 @@ export default function QuestionnaireNavigation() {
       ],
     },
     {
-      label: t('questionnaires.navigation.metadata'),
+      label: t('metadata.title'),
       Icon: DescriptionIcon,
       path: '/',
       isDisabled: true,
       isHidden: true,
     },
     {
-      label: t('questionnaires.navigation.nomenclatures'),
+      label: t('nomenclatures.title'),
       Icon: showAltIcon ? NomenclatureAltIcon : DictionaryIcon,
       iconClassName: showAltIcon ? 'animate-bounce' : '',
       onIconClick: handleAltIconClick,
@@ -73,7 +73,7 @@ export default function QuestionnaireNavigation() {
    */
   const questionnaireItems: NavigationItem[] = [
     {
-      label: t('questionnaires.navigation.history'),
+      label: t('history.title'),
       Icon: HistoryIcon,
       path: '/questionnaire/$questionnaireId/versions',
     },
@@ -86,7 +86,7 @@ export default function QuestionnaireNavigation() {
           <Button
             buttonSize={ButtonSize.sm}
             className="w-full flex overflow-hidden disabled:bg-main disabled:!text-default disabled:!cursor-auto"
-            title={t('version.backToLatest')}
+            title={t('history.backToLatest')}
             disabled={!versionId}
             onClick={() => {
               if (versionId) {

--- a/next/src/components/layout/QuestionnaireNavigation.tsx
+++ b/next/src/components/layout/QuestionnaireNavigation.tsx
@@ -1,17 +1,17 @@
 import { useNavigate, useParams } from '@tanstack/react-router';
 import { useTranslation } from 'react-i18next';
 
-import Option from '@/components/ui/form/Option';
-import Select from '@/components/ui/form/Select';
 import DashboardIcon from '@/components/ui/icons/DashboardIcon';
 import DescriptionIcon from '@/components/ui/icons/DescriptionIcon';
 import DictionaryIcon from '@/components/ui/icons/DictionaryIcon';
 import HistoryIcon from '@/components/ui/icons/HistoryIcon';
+import LatestIcon from '@/components/ui/icons/LatestIcon';
 import ListIcon from '@/components/ui/icons/ListIcon';
 import NomenclatureAltIcon from '@/components/ui/icons/NomenclatureAltIcon';
 import VariableIcon from '@/components/ui/icons/VariableIcon';
 import { useAltIcon } from '@/hooks/useAltIcon';
 
+import Button, { ButtonSize } from '../ui/Button';
 import NavigationBar, { type NavigationItem } from './NavigationBar';
 
 /** Display the available navigation items in a questionnaire. */
@@ -26,21 +26,21 @@ export default function QuestionnaireNavigation() {
   const questionnaireVersionItems: NavigationItem[] = [
     {
       label: t('questionnaires.navigation.overview'),
-      icon: <DashboardIcon className="m-auto" />,
+      Icon: DashboardIcon,
       path: versionId
         ? `/questionnaire/$questionnaireId/version/$versionId`
         : '/questionnaire/$questionnaireId',
     },
     {
       label: t('questionnaires.navigation.variables'),
-      icon: <VariableIcon className="m-auto" />,
+      Icon: VariableIcon,
       path: '/',
       isDisabled: true,
       isHidden: true,
     },
     {
       label: t('questionnaires.navigation.codeLists'),
-      icon: <ListIcon className="m-auto" />,
+      Icon: ListIcon,
       path: versionId
         ? `/questionnaire/$questionnaireId/version/$versionId/codes-lists`
         : '/questionnaire/$questionnaireId/codes-lists',
@@ -51,18 +51,16 @@ export default function QuestionnaireNavigation() {
     },
     {
       label: t('questionnaires.navigation.metadata'),
-      icon: <DescriptionIcon className="m-auto" />,
+      Icon: DescriptionIcon,
       path: '/',
       isDisabled: true,
       isHidden: true,
     },
     {
       label: t('questionnaires.navigation.nomenclatures'),
-      icon: showAltIcon ? (
-        <NomenclatureAltIcon className="m-auto animate-bounce" />
-      ) : (
-        <DictionaryIcon onClick={handleAltIconClick} className="m-auto" />
-      ),
+      Icon: showAltIcon ? NomenclatureAltIcon : DictionaryIcon,
+      iconClassName: showAltIcon ? 'animate-bounce' : '',
+      onIconClick: handleAltIconClick,
       path: versionId
         ? `/questionnaire/$questionnaireId/version/$versionId/nomenclatures`
         : '/questionnaire/$questionnaireId/nomenclatures',
@@ -76,29 +74,34 @@ export default function QuestionnaireNavigation() {
   const questionnaireItems: NavigationItem[] = [
     {
       label: t('questionnaires.navigation.history'),
-      icon: <HistoryIcon className="m-auto" />,
+      Icon: HistoryIcon,
       path: '/questionnaire/$questionnaireId/versions',
     },
   ];
 
   return (
-    <div className="sticky top-0 w-52 max-h-[calc(100vh-var(--header-height))] divide-y *:py-3 *:first:pt-0 *:last:pb-0">
+    <div className="sticky top-0 w-18 2xl:w-52 max-h-[calc(100vh-var(--header-height))] divide-y *:py-3 *:first:pt-0 *:last:pb-0">
       <div>
-        <div className="p-3 overflow-hidden">
-          <Select
-            onChange={(v) => {
-              if (v === 'latest') {
+        <div className="p-1 py-3 2xl:px-3">
+          <Button
+            buttonSize={ButtonSize.sm}
+            className="w-full flex overflow-hidden disabled:bg-main disabled:!text-default disabled:!cursor-auto"
+            title={t('version.backToLatest')}
+            disabled={!versionId}
+            onClick={() => {
+              if (versionId) {
                 navigate({
                   to: '/questionnaire/$questionnaireId',
                   params: { questionnaireId: questionnaireId! },
                 });
               }
             }}
-            value={versionId ?? 'latest'}
           >
-            <Option value={'latest'}>latest</Option>
-            {versionId ? <Option value={versionId}>{versionId}</Option> : null}
-          </Select>
+            <span className="text-sm/8 font-bold overflow-hidden text-ellipsis ">
+              {versionId ?? 'latest'}
+            </span>
+            {versionId ? <LatestIcon className="size-8" /> : null}
+          </Button>
         </div>
         <NavigationBar
           questionnaireId={questionnaireId}

--- a/next/src/components/layout/ReadonlyWarning.tsx
+++ b/next/src/components/layout/ReadonlyWarning.tsx
@@ -57,7 +57,7 @@ export default function ReadonlyWarning({
     );
     toast.promise(promise, {
       loading: t('common.loading'),
-      success: t('version.restoreSuccess', {
+      success: t('history.restore.success', {
         label: versionId,
       }),
       error: (err: Error) => err.toString(),
@@ -66,14 +66,14 @@ export default function ReadonlyWarning({
 
   return (
     <div className="grid grid-cols-[1fr_auto] items-center p-3 border-blue-3 border rounded shadow m-3 bg-default">
-      <div>{t('version.surveyIsReadonly')}</div>
+      <div>{t('history.questionnaireIsReadonly')}</div>
       {versionId ? (
         <Dialog
-          body={t('version.restoreDialogConfirm')}
+          body={t('history.restore.dialogConfirm')}
           buttonSize={ButtonSize.sm}
-          label={t('version.restore')}
+          label={t('history.restore.label')}
           onValidate={onRestore}
-          title={t('version.restoreDialogTitle')}
+          title={t('history.restore.dialogTitle')}
         />
       ) : null}
     </div>

--- a/next/src/components/nomenclatures/NomenclatureOverview.tsx
+++ b/next/src/components/nomenclatures/NomenclatureOverview.tsx
@@ -1,5 +1,6 @@
 import { useTranslation } from 'react-i18next';
 
+import FilterList from '@/components/ui/FilterList';
 import Input from '@/components/ui/form/Input';
 import { useFilters } from '@/hooks/useFilter';
 import { FilterEnum } from '@/models/filter';
@@ -20,7 +21,7 @@ export default function NomenclaturesOverview({
 }: Readonly<NomenclaturesProps>) {
   const { t } = useTranslation();
 
-  const { updateFilterContent, getFilterContent } = useFilters([
+  const { filters, updateFilterContent, getFilterContent } = useFilters([
     {
       filterType: FilterEnum.Search,
       filterContent: '',
@@ -35,7 +36,7 @@ export default function NomenclaturesOverview({
     )
     .toSorted((a, b) => a.label.localeCompare(b.label));
 
-  return (
+  return nomenclatures.length > 0 ? (
     <>
       <div>
         <Input
@@ -49,20 +50,23 @@ export default function NomenclaturesOverview({
           showClearButton={searchFilterContent.length > 0}
         />
       </div>
-      {filteredNomenclatures.length > 0 ? (
-        <ul>
-          {filteredNomenclatures.map((nomenclature) => (
-            <NomenclatureOverviewItem
-              key={nomenclature.id}
-              nomenclature={nomenclature}
-            />
-          ))}
-        </ul>
-      ) : (
-        <div className="text-center">
-          <p>{t('nomenclatures.noNomenclatures')}</p>
-        </div>
-      )}
+      <FilterList
+        filters={filters}
+        resultCount={filteredNomenclatures.length}
+        updateFilterContent={updateFilterContent}
+      />
+      <ul>
+        {filteredNomenclatures.map((nomenclature) => (
+          <NomenclatureOverviewItem
+            key={nomenclature.id}
+            nomenclature={nomenclature}
+          />
+        ))}
+      </ul>
     </>
+  ) : (
+    <div>
+      <p>{t('nomenclatures.notUsedByQuestionnaire')}</p>
+    </div>
   );
 }

--- a/next/src/components/ui/Button.tsx
+++ b/next/src/components/ui/Button.tsx
@@ -23,6 +23,7 @@ interface ButtonProps extends React.ButtonHTMLAttributes<HTMLButtonElement> {
 export default function Button({
   buttonSize = ButtonSize.md,
   buttonStyle = ButtonStyle.Secondary,
+  className = '',
   children,
   disabled = false,
   isLoading = false,
@@ -34,12 +35,12 @@ export default function Button({
       onClick={!disabled ? onClick : undefined}
       disabled={disabled || isLoading}
       aria-disabled={disabled || isLoading}
-      className={`border cursor-pointer font-semibold transition rounded disabled:cursor-not-allowed outline-hidden focus-visible:outline focus-visible:outline-offset-2 focus-visible:outline-primary
+      className={`${className} border cursor-pointer font-semibold transition rounded disabled:cursor-not-allowed outline-hidden focus-visible:outline focus-visible:outline-offset-2 focus-visible:outline-primary text-nowrap
         ${
           buttonStyle === ButtonStyle.Primary
             ? 'bg-primary text-negative disabled:bg-primary-disabled hover:enabled:bg-primary-accent active:enabled:bg-primary-active'
-            : 'bg-white text-primary disabled:bg-disabled disabled:text-disabled hover:enabled:bg-accent active:enabled:bg-active disabled:border-default border-primary'
-        } ${buttonSize === ButtonSize.md ? 'px-4 py-3 min-w-40' : 'px-2 p-1'}`}
+            : 'bg-white text-primary fill-action-primary disabled:bg-disabled disabled:text-disabled hover:enabled:bg-accent active:enabled:bg-active disabled:border-default border-primary'
+        } ${buttonSize === ButtonSize.md ? 'px-4 py-3 min-w-40' : 'px-2 py-1'}`}
       {...props}
     >
       {isLoading ? (

--- a/next/src/components/ui/FilterList.tsx
+++ b/next/src/components/ui/FilterList.tsx
@@ -28,13 +28,13 @@ const FilterList: React.FC<FilterListProps> = ({
 
   return (
     <div className="flex flex-row gap-3 mv-4 items-baseline">
-      <span className="font-medium text-md">
+      <span className="font-medium text-base/10">
         {t('filter.active', { count: activeFilterCount })}&nbsp;
       </span>
-      {filters.map((filter, index) =>
+      {filters.map((filter) =>
         typeof filter.filterContent === 'boolean' ? (
           <div
-            key={index}
+            key={filter.filterType}
             className={`border px-1 py-2 rounded-full flex items-center ${
               filter.filterContent
                 ? 'bg-primary text-white'
@@ -61,23 +61,19 @@ const FilterList: React.FC<FilterListProps> = ({
         ) : (
           filter.filterContent && (
             <div
-              key={index}
-              className="border p-1 rounded-full flex items-center bg-slate-200"
+              key={filter.filterType}
+              className="border px-1 py-2 rounded-full flex items-center bg-primary text-white"
             >
               <div className="flex items-center ml-2">
-                <span className="font-medium text-sm">
-                  {t(`filter.${filter.filterType}`)}:&nbsp;
+                <span className="text-sm mr-2">
+                  {t(`filter.${filter.filterType}`)}: {filter.filterContent}
                 </span>
-                <span className="font-normal text-xs">
-                  {filter.filterContent}
-                </span>
-                <ButtonIcon
-                  className="ml-2"
-                  Icon={CloseIcon}
-                  iconProps={{ height: '16px', width: '16px' }}
-                  title={t('filter.clear')}
-                  onClick={filter.clearFilterFunction || (() => {})}
-                />
+                <button title={t('filter.clear')}>
+                  <CloseIcon
+                    className={`cursor-pointer m-auto size-5 fill-white`}
+                    onClick={filter.clearFilterFunction}
+                  />
+                </button>
               </div>
             </div>
           )

--- a/next/src/components/ui/icons/LatestIcon.tsx
+++ b/next/src/components/ui/icons/LatestIcon.tsx
@@ -1,0 +1,18 @@
+/** Resume icon which should be used when one wants to go back to latest save. */
+export default function LatestIcon({
+  height = '24px',
+  width = '24px',
+  ...props
+}: Readonly<React.ComponentProps<'svg'>>) {
+  return (
+    <svg
+      xmlns="http://www.w3.org/2000/svg"
+      height={height}
+      viewBox="0 -960 960 960"
+      width={width}
+      {...props}
+    >
+      <path d="M240-240v-480h80v480h-80Zm160 0 400-240-400-240v480Zm80-141v-198l165 99-165 99Zm0-99Z" />{' '}
+    </svg>
+  );
+}

--- a/next/src/components/versions/VersionTile.tsx
+++ b/next/src/components/versions/VersionTile.tsx
@@ -28,10 +28,10 @@ export default function VersionTile({
     <table className="border border-default w-full shadow-sm">
       <thead className="bg-accent">
         <tr className="*:font-semibold *:p-4 text-left">
-          <th>{t('version.id')}</th>
+          <th>{t('history.id')}</th>
           <th>{t('common.lastUpdated')}</th>
           <th>{t('common.date')}</th>
-          <th>{t('version.author')}</th>
+          <th>{t('history.author')}</th>
           <th />
         </tr>
       </thead>
@@ -67,7 +67,7 @@ export default function VersionTile({
                 to="/questionnaire/$questionnaireId/version/$versionId"
                 params={{ questionnaireId, versionId: version.id }}
               >
-                {t('version.view')}
+                {t('history.view')}
               </ButtonLink>
             </td>
           </tr>

--- a/next/src/components/versions/VersionsOverview.tsx
+++ b/next/src/components/versions/VersionsOverview.tsx
@@ -51,7 +51,7 @@ export default function VersionsOverview({
     });
     toast.promise(promise, {
       loading: t('common.loading'),
-      success: t('version.deleteSuccess'),
+      success: t('history.deleteAll.success'),
       error: (err: Error) => err.toString(),
     });
   }
@@ -59,12 +59,12 @@ export default function VersionsOverview({
   return (
     <div>
       <ContentHeader
-        title={`${t('version.title')} : ${versions.length}`}
+        title={t('history.title')}
         action={
           <Dialog
-            label={t('version.deleteAll')}
-            title={t('version.deleteDialogTitle')}
-            body={t('version.deleteDialogConfirm')}
+            label={t('history.deleteAll.label')}
+            title={t('history.deleteAll.dialogTitle')}
+            body={t('history.deleteAll.dialogConfirm')}
             onValidate={onDelete}
           />
         }
@@ -75,19 +75,19 @@ export default function VersionsOverview({
             <VersionContent
               versions={todaysVersions}
               questionnaireId={questionnaireId}
-              label={t('version.version_today', {
+              label={t('history.versionToday', {
                 count: todaysVersions.length,
               })}
             />
             <VersionContent
               versions={olderVersions}
               questionnaireId={questionnaireId}
-              label={t('version.old_versions', { count: olderVersions.length })}
+              label={t('history.oldVersions', { count: olderVersions.length })}
             />
           </>
         ) : (
           <div className="text-center">
-            <p>{t('version.no_versions')}</p>
+            <p>{t('history.noVersions')}</p>
           </div>
         )}
       </ContentMain>

--- a/next/src/i18n/locales/en.json
+++ b/next/src/i18n/locales/en.json
@@ -92,7 +92,9 @@
     "clear": "Clear",
     "clearFilters": "Clear filters",
     "questionUsed": "Not used",
-    "result": "Result: {{count}}",
+    "result": "{{count}} result",
+    "result_other": "{{count}} results",
+    "result_zero": "{{count}} results",
     "search": "Label",
     "stamp": "Stamp"
   },
@@ -154,7 +156,7 @@
     "title": "Metadata"
   },
   "nomenclatures": {
-    "noNomenclatures": "No nomenclatures available",
+    "notUsedByQuestionnaire": "The questionnaire does not use nomenclatures.",
     "search": "Search for a nomenclature",
     "title": "Nomenclatures",
     "version": "Version"

--- a/next/src/i18n/locales/en.json
+++ b/next/src/i18n/locales/en.json
@@ -34,8 +34,24 @@
       "success": "The code list has been created",
       "title": "New code list"
     },
+    "delete": {
+      "dialogConfirm": "Are you sure you want to delete this code list?",
+      "dialogTitle": "Delete code list: {{label}}",
+      "disabled": {
+        "usedByQuestions": "Code list cannot be deleted if it used by a question."
+      },
+      "error": {
+        "usedByQuestions": "The code list is used by questions: {{questions}}"
+      },
+      "success": "Code list {{label}} deleted"
+    },
+    "duplicate": {
+      "dialogConfirm": "Voulez-vous créer une copie de cette liste de codes ?",
+      "dialogTitle": "Dupliquer la liste de codes : {{label}}",
+      "label": "Duplicate",
+      "success": "Liste de codes {{label}} dupliquée"
+    },
     "edit": {
-      "crumb": "Code list {{id}}",
       "success": "The code list {{label}} has been edited",
       "title": "Edit the code list: {{label}}"
     },
@@ -50,24 +66,23 @@
       "moveUp": "Move up",
       "moveDown": "Move down"
     },
-    "overview": {
-      "create": "Create a code list",
-      "deleteDialogConfirm": "Are you sure you want to delete this code list?",
-      "deleteDialogTitle": "Delete code list: {{label}}",
-      "deleteDisabled": {
-        "usedByQuestions": "Code list cannot be deleted if it used by a question."
-      },
-      "deleteError": {
-        "usedByQuestions": "The code list is used by questions: {{questions}}"
-      },
-      "deleteSuccess": "Code list {{label}} deleted",
-      "duplicate": "Duplicate",
-      "duplicateDialogConfirm": "Do you want to create a copy of this code list?",
-      "duplicateDialogTitle": "Duplicate code list: {{label}}",
-      "duplicateSuccess": "Code list {{label}} duplicated",
-      "search": "Search for a code list"
-    },
     "title": "Codes list"
+  },
+  "codesLists": {
+    "create": "Create a codes list",
+    "search": "Search for a code list",
+    "title": "Codes lists"
+  },
+  "crumb": {
+    "codesList": "Codes list {{id}}",
+    "codesLists": "Codes lists",
+    "edit": "Edit",
+    "history": "History",
+    "new": "New",
+    "nomenclatures": "Nomenclatures",
+    "questionnaire": "Questionnaire {{id}}",
+    "questionnaires": "Questionnaires",
+    "version": "Version {{id}}"
   },
   "error": {
     "boundary": "An error occurred, if the problem persists, please contact support."
@@ -80,6 +95,30 @@
     "result": "Result: {{count}}",
     "search": "Label",
     "stamp": "Stamp"
+  },
+  "history": {
+    "author": "Author",
+    "backToLatest": "Back to latest save",
+    "deleteAll": {
+      "label": "Delete all saves",
+      "dialogConfirm": "Are you sure you want to delete all saves?",
+      "dialogTitle": "Delete all saved versions",
+      "success": "Version from{{timestamp}} deleted"
+    },
+    "id": "ID",
+    "noVersions": "No saves were found",
+    "oldVersions": "{{count}} older versions",
+    "questionnaireIsReadonly": "This save of the survey is on readonly.",
+    "restore": {
+      "label": "Restore",
+      "dialogConfirm": "A new save will be created with this save data.",
+      "dialogTitle": "Restore this save data",
+      "success": "A new save has been created"
+    },
+    "timestamp": "Timestamp",
+    "title": "History",
+    "versionToday": "{{count}} version today",
+    "view": "View"
   },
   "questionnaire": {
     "common": {
@@ -97,21 +136,22 @@
       "mustProvideTarget": "You must select at least one target mode",
       "mustProvideTitle": "You must provide a title"
     },
+    "navigation": {
+      "codesLists": "Codes lists",
+      "metadata": "Metadata",
+      "nomenclatures": "Nomenclatures",
+      "variables": "Variables"
+    },
     "title": "Questionnaire {{id}}"
   },
   "questionnaires": {
     "create": "Create a questionnaire",
-    "navigation": {
-      "codeLists": "Code lists",
-      "history": "History",
-      "metadata": "Metadata",
-      "nomenclatures": "Nomenclatures",
-      "overview": "Overview",
-      "variables": "Variables"
-    },
     "search": "Search for a questionnaire",
     "stamp": "Stamp",
     "title": "Questionnaires"
+  },
+  "metadata": {
+    "title": "Metadata"
   },
   "nomenclatures": {
     "noNomenclatures": "No nomenclatures available",
@@ -119,25 +159,7 @@
     "title": "Nomenclatures",
     "version": "Version"
   },
-  "version": {
-    "author": "Author",
-    "backToLatest": "Back to latest save",
-    "crumb": "Version {{id}}",
-    "deleteAll": "Delete all saves",
-    "deleteDialogConfirm": "Are you sure you want to delete all saves?",
-    "deleteDialogTitle": "Delete all saved versions",
-    "deleteSuccess": "Version from{{timestamp}} deleted",
-    "id": "ID",
-    "no_versions": "No saves were found",
-    "old_versions": "{{count}} older versions",
-    "restore": "Restore",
-    "restoreDialogConfirm": "A new save will be created with this save data.",
-    "restoreDialogTitle": "Restore this save data",
-    "restoreSuccess": "A new save has been created",
-    "surveyIsReadonly": "This save of the survey is on readonly.",
-    "timestamp": "Timestamp",
-    "title": "History",
-    "version_today": "{{count}} version today",
-    "view": "View"
+  "variables": {
+    "title": "Variables"
   }
 }

--- a/next/src/i18n/locales/en.json
+++ b/next/src/i18n/locales/en.json
@@ -121,6 +121,7 @@
   },
   "version": {
     "author": "Author",
+    "backToLatest": "Back to latest save",
     "crumb": "Version {{id}}",
     "deleteAll": "Delete all saves",
     "deleteDialogConfirm": "Are you sure you want to delete all saves?",

--- a/next/src/i18n/locales/fr.json
+++ b/next/src/i18n/locales/fr.json
@@ -92,7 +92,9 @@
     "clear": "Supprimer le filtre",
     "clearFilters": "Supprimer les filtres",
     "questionUsed": "Non utilisées",
-    "result": "Resultat : {{count}}",
+    "result": "{{count}} résultat",
+    "result_other": "{{count}} résultats",
+    "result_zero": "{{count}} résultat",
     "search": "Label",
     "stamp": "Timbre"
   },
@@ -156,7 +158,7 @@
     "title": "Métadonnées"
   },
   "nomenclatures": {
-    "noNomenclatures": "Aucune nomenclature trouvée",
+    "notUsedByQuestionnaire": "Le questionnaire n'utilise pas de nomenclature.",
     "search": "Rechercher une nomenclature",
     "title": "Nomenclatures",
     "version": "Version"

--- a/next/src/i18n/locales/fr.json
+++ b/next/src/i18n/locales/fr.json
@@ -121,6 +121,7 @@
   },
   "version": {
     "author": "Auteur",
+    "backToLatest": "Retour à la dernière sauvegarde",
     "crumb": "Version {{id}}",
     "deleteAll": "Supprimer toutes les sauvegardes",
     "deleteDialogConfirm": "Êtes-vous sûr de vouloir supprimer toutes les sauvegardes ?",

--- a/next/src/i18n/locales/fr.json
+++ b/next/src/i18n/locales/fr.json
@@ -34,8 +34,24 @@
       "success": "La liste de codes a été créée",
       "title": "Nouvelle liste de codes"
     },
+    "delete": {
+      "dialogConfirm": "Êtes-vous sûr de vouloir supprimer cette liste de codes ?",
+      "dialogTitle": "Supprimer la liste de codes : {{label}}",
+      "disabled": {
+        "usedByQuestions": "La liste de codes ne peut pas être supprimée si elle est utilisée dans une question."
+      },
+      "error": {
+        "usedByQuestions": "La liste de codes est utilisée dans les questions : {{questions}}"
+      },
+      "success": "Liste de codes {{label}} supprimée"
+    },
+    "duplicate": {
+      "dialogConfirm": "Voulez-vous créer une copie de cette liste de codes ?",
+      "dialogTitle": "Dupliquer la liste de codes : {{label}}",
+      "label": "Dupliquer",
+      "success": "Liste de codes {{label}} dupliquée"
+    },
     "edit": {
-      "crumb": "Liste de codes {{id}}",
       "success": "La liste de codes {{label}} a été modifiée",
       "title": "Editer la liste de codes : {{label}}"
     },
@@ -50,36 +66,59 @@
       "moveUp": "Monter d'un niveau",
       "moveDown": "Descendre d'un niveau"
     },
-    "overview": {
-      "create": "Créer une liste de codes",
-      "deleteDialogConfirm": "Êtes-vous sûr de vouloir supprimer cette liste de codes ?",
-      "deleteDialogTitle": "Supprimer la liste de codes : {{label}}",
-      "deleteDisabled": {
-        "usedByQuestions": "La liste de codes ne peut pas être supprimée si elle est utilisée dans une question."
-      },
-      "deleteError": {
-        "usedByQuestions": "La liste de codes est utilisée dans les questions : {{questions}}"
-      },
-      "deleteSuccess": "Liste de codes {{label}} supprimée",
-      "duplicate": "Dupliquer",
-      "duplicateDialogConfirm": "Voulez-vous créer une copie de cette liste de codes ?",
-      "duplicateDialogTitle": "Dupliquer la liste de codes : {{label}}",
-      "duplicateSuccess": "Liste de codes {{label}} dupliquée",
-      "search": "Rechercher une liste de codes"
-    },
+    "title": "Liste de codes"
+  },
+  "codesLists": {
+    "create": "Créer une liste de codes",
+    "search": "Rechercher une liste de codes",
     "title": "Listes de codes"
+  },
+  "crumb": {
+    "codesList": "Liste de code {{id}}",
+    "codesLists": "Listes de codes",
+    "edit": "Editer",
+    "history": "Historique",
+    "new": "Nouveau",
+    "nomenclatures": "Nomenclatures",
+    "questionnaire": "Questionnaire {{id}}",
+    "questionnaires": "Questionnaires",
+    "version": "Version {{id}}"
   },
   "error": {
     "boundary": "Un problème est survenu, si le problème persiste, veuillez contacter l'assistance."
   },
   "filter": {
     "active": "Filtrer par:",
-    "clear": "Suprimer le filtre",
+    "clear": "Supprimer le filtre",
     "clearFilters": "Supprimer les filtres",
     "questionUsed": "Non utilisées",
     "result": "Resultat : {{count}}",
     "search": "Label",
     "stamp": "Timbre"
+  },
+  "history": {
+    "author": "Auteur",
+    "backToLatest": "Retour à la dernière sauvegarde",
+    "deleteAll": {
+      "label": "Supprimer toutes les sauvegardes",
+      "dialogConfirm": "Êtes-vous sûr de vouloir supprimer toutes les sauvegardes ?",
+      "dialogTitle": "Supprimer toutes les sauvegardes",
+      "success": "Version de {{timestamp}} supprimée"
+    },
+    "id": "ID",
+    "noVersions": "Aucune sauvegarde disponible",
+    "oldVersions": "{{count}} sauvegardes plus anciennes",
+    "questionnaireIsReadonly": "Cette sauvegarde du questionnaire est en lecture seule.",
+    "restore": {
+      "label": "Restaurer",
+      "dialogConfirm": "Une nouvelle sauvegarde va être créée avec ces données.",
+      "dialogTitle": "Restaurer cette sauvegarde",
+      "success": "La nouvelle sauvegarde a été créée"
+    },
+    "timestamp": "Date",
+    "title": "Historique",
+    "versionToday": "{{count}} sauvegardes aujourd'hui",
+    "view": "Consulter"
   },
   "questionnaire": {
     "common": {
@@ -97,21 +136,24 @@
       "mustProvideTarget": "Vous devez sélectionner au moins un mode de collecte",
       "mustProvideTitle": "Vous devez renseigner un titre"
     },
-    "title": "Questionnaire {{id}}"
-  },
-  "questionnaires": {
-    "create": "Créer un questionnaire",
     "navigation": {
-      "codeLists": "Listes de codes",
+      "codesLists": "Listes de codes",
       "history": "Historique",
       "metadata": "Métadonnées",
       "nomenclatures": "Nomenclatures",
-      "overview": "Vue d'ensemble",
+      "questionnaire": "Questionnaire",
       "variables": "Variables"
     },
+    "title": "Questionnaire"
+  },
+  "questionnaires": {
+    "create": "Créer un questionnaire",
     "search": "Rechercher un questionnaire",
     "stamp": "Timbre",
     "title": "Questionnaires"
+  },
+  "metadata": {
+    "title": "Métadonnées"
   },
   "nomenclatures": {
     "noNomenclatures": "Aucune nomenclature trouvée",
@@ -119,25 +161,7 @@
     "title": "Nomenclatures",
     "version": "Version"
   },
-  "version": {
-    "author": "Auteur",
-    "backToLatest": "Retour à la dernière sauvegarde",
-    "crumb": "Version {{id}}",
-    "deleteAll": "Supprimer toutes les sauvegardes",
-    "deleteDialogConfirm": "Êtes-vous sûr de vouloir supprimer toutes les sauvegardes ?",
-    "deleteDialogTitle": "Supprimer toutes les sauvegardes",
-    "deleteSuccess": "Version de {{timestamp}} supprimée",
-    "id": "ID",
-    "no_versions": "Aucune sauvegarde disponible",
-    "old_versions": "{{count}} sauvegardes plus anciennes",
-    "restore": "Restaurer",
-    "restoreDialogConfirm": "Une nouvelle sauvegarde va être créée avec ces données.",
-    "restoreDialogTitle": "Restaurer cette sauvegarde",
-    "restoreSuccess": "La nouvelle sauvegarde a été créée",
-    "surveyIsReadonly": "Cette sauvegarde du questionnaire est en lecture seule.",
-    "timestamp": "Date",
-    "title": "Historique",
-    "version_today": "{{count}} sauvegardes aujourd'hui",
-    "view": "Consulter"
+  "variables": {
+    "title": "Variables"
   }
 }

--- a/next/src/routes/_layout/questionnaire.$questionnaireId/_layout-q/codes-list/$codesListId.tsx
+++ b/next/src/routes/_layout/questionnaire.$questionnaireId/_layout-q/codes-list/$codesListId.tsx
@@ -23,7 +23,7 @@ export const Route = createFileRoute(
   }) => {
     queryClient.ensureQueryData(questionnaireQueryOptions(questionnaireId));
     queryClient.ensureQueryData(variablesQueryOptions(questionnaireId));
-    return { crumb: t('codesList.edit.crumb', { id: codesListId }) };
+    return { crumb: t('crumb.codesList', { id: codesListId }) };
   },
 });
 

--- a/next/src/routes/_layout/questionnaire.$questionnaireId/_layout-q/codes-lists/index.tsx
+++ b/next/src/routes/_layout/questionnaire.$questionnaireId/_layout-q/codes-lists/index.tsx
@@ -28,10 +28,7 @@ function RouteComponent() {
   );
 
   return (
-    <ComponentWrapper
-      codesListsCount={codesLists.length}
-      questionnaireId={questionnaireId}
-    >
+    <ComponentWrapper>
       <CodesListsOverview
         questionnaireId={questionnaireId}
         codesLists={codesLists}
@@ -41,9 +38,8 @@ function RouteComponent() {
 }
 
 function ErrorComponent({ error }: Readonly<{ error: Error }>) {
-  const questionnaireId = Route.useParams().questionnaireId;
   return (
-    <ComponentWrapper questionnaireId={questionnaireId}>
+    <ComponentWrapper>
       <div className="text-error">{error.message}</div>
     </ComponentWrapper>
   );
@@ -51,25 +47,20 @@ function ErrorComponent({ error }: Readonly<{ error: Error }>) {
 
 function ComponentWrapper({
   children,
-  codesListsCount,
-  questionnaireId,
-}: Readonly<{
-  children: React.ReactNode;
-  codesListsCount?: number;
-  questionnaireId: string;
-}>) {
+}: Readonly<{ children: React.ReactNode }>) {
   const { t } = useTranslation();
-  const codesListsAffix = codesListsCount ? `: ${codesListsCount}` : '';
+  const questionnaireId = Route.useParams().questionnaireId;
+
   return (
     <>
       <ContentHeader
-        title={`${t('codesList.title')} ${codesListsAffix}`}
+        title={t('questionnaire.navigation.codesLists')}
         action={
           <ButtonLink
             to="/questionnaire/$questionnaireId/codes-lists/new"
             params={{ questionnaireId }}
           >
-            {t('codesList.overview.create')}
+            {t('codesLists.create')}
           </ButtonLink>
         }
       />

--- a/next/src/routes/_layout/questionnaire.$questionnaireId/_layout-q/codes-lists/new.tsx
+++ b/next/src/routes/_layout/questionnaire.$questionnaireId/_layout-q/codes-lists/new.tsx
@@ -22,7 +22,7 @@ export const Route = createFileRoute(
   }) => {
     queryClient.ensureQueryData(questionnaireQueryOptions(questionnaireId));
     queryClient.ensureQueryData(variablesQueryOptions(questionnaireId));
-    return { crumb: t('common.new') };
+    return { crumb: t('crumb.new') };
   },
 });
 

--- a/next/src/routes/_layout/questionnaire.$questionnaireId/_layout-q/codes-lists/route.tsx
+++ b/next/src/routes/_layout/questionnaire.$questionnaireId/_layout-q/codes-lists/route.tsx
@@ -4,5 +4,5 @@ import { createFileRoute } from '@tanstack/react-router';
 export const Route = createFileRoute(
   '/_layout/questionnaire/$questionnaireId/_layout-q/codes-lists',
 )({
-  loader: ({ context: { t } }) => ({ crumb: t('codesList.title') }),
+  loader: ({ context: { t } }) => ({ crumb: t('crumb.codesLists') }),
 });

--- a/next/src/routes/_layout/questionnaire.$questionnaireId/_layout-q/composition.tsx
+++ b/next/src/routes/_layout/questionnaire.$questionnaireId/_layout-q/composition.tsx
@@ -1,9 +1,22 @@
 import { createFileRoute } from '@tanstack/react-router';
+import { useTranslation } from 'react-i18next';
 
+import ContentHeader from '@/components/layout/ContentHeader';
 import { LegacyComponent } from '@/components/legacy';
 
 export const Route = createFileRoute(
   '/_layout/questionnaire/$questionnaireId/_layout-q/composition',
 )({
-  component: LegacyComponent,
+  component: RouteComponent,
 });
+
+function RouteComponent() {
+  const { t } = useTranslation();
+
+  return (
+    <>
+      <ContentHeader title={t('questionnaire.title')} />
+      <LegacyComponent />
+    </>
+  );
+}

--- a/next/src/routes/_layout/questionnaire.$questionnaireId/_layout-q/duplicate-variables.tsx
+++ b/next/src/routes/_layout/questionnaire.$questionnaireId/_layout-q/duplicate-variables.tsx
@@ -1,9 +1,22 @@
 import { createFileRoute } from '@tanstack/react-router';
+import { useTranslation } from 'react-i18next';
 
+import ContentHeader from '@/components/layout/ContentHeader';
 import { LegacyComponent } from '@/components/legacy';
 
 export const Route = createFileRoute(
   '/_layout/questionnaire/$questionnaireId/_layout-q/duplicate-variables',
 )({
-  component: LegacyComponent,
+  component: RouteComponent,
 });
+
+function RouteComponent() {
+  const { t } = useTranslation();
+
+  return (
+    <>
+      <ContentHeader title={t('questionnaire.title')} />
+      <LegacyComponent />
+    </>
+  );
+}

--- a/next/src/routes/_layout/questionnaire.$questionnaireId/_layout-q/index.tsx
+++ b/next/src/routes/_layout/questionnaire.$questionnaireId/_layout-q/index.tsx
@@ -16,13 +16,10 @@ export const Route = createFileRoute(
 
 function RouteComponent() {
   const { t } = useTranslation();
-  const questionnaireId = Route.useParams().questionnaireId;
 
   return (
     <>
-      <ContentHeader
-        title={t('questionnaire.title', { id: questionnaireId })}
-      />
+      <ContentHeader title={t('questionnaire.title')} />
       <LegacyComponent />
     </>
   );

--- a/next/src/routes/_layout/questionnaire.$questionnaireId/_layout-q/merge.tsx
+++ b/next/src/routes/_layout/questionnaire.$questionnaireId/_layout-q/merge.tsx
@@ -1,9 +1,22 @@
 import { createFileRoute } from '@tanstack/react-router';
+import { useTranslation } from 'react-i18next';
 
+import ContentHeader from '@/components/layout/ContentHeader';
 import { LegacyComponent } from '@/components/legacy';
 
 export const Route = createFileRoute(
   '/_layout/questionnaire/$questionnaireId/_layout-q/merge',
 )({
-  component: LegacyComponent,
+  component: RouteComponent,
 });
+
+function RouteComponent() {
+  const { t } = useTranslation();
+
+  return (
+    <>
+      <ContentHeader title={t('questionnaire.title')} />
+      <LegacyComponent />
+    </>
+  );
+}

--- a/next/src/routes/_layout/questionnaire.$questionnaireId/_layout-q/nomenclatures/index.tsx
+++ b/next/src/routes/_layout/questionnaire.$questionnaireId/_layout-q/nomenclatures/index.tsx
@@ -28,7 +28,7 @@ function RouteComponent() {
   );
 
   return (
-    <ComponentWrapper nomenclaturesCount={data.length}>
+    <ComponentWrapper>
       <NomenclaturesOverview
         questionnaireId={questionnaireId}
         nomenclatures={data}
@@ -47,17 +47,12 @@ function ErrorComponent({ error }: Readonly<{ error: Error }>) {
 
 function ComponentWrapper({
   children,
-  nomenclaturesCount,
-}: Readonly<{ children: React.ReactNode; nomenclaturesCount?: number }>) {
+}: Readonly<{ children: React.ReactNode }>) {
   const { t } = useTranslation();
-  const nomenclaturesAffix = nomenclaturesCount
-    ? `: ${nomenclaturesCount}`
-    : '';
+
   return (
     <>
-      <ContentHeader
-        title={`${t('nomenclatures.title')} ${nomenclaturesAffix}`}
-      />
+      <ContentHeader title={t('nomenclatures.title')} />
       <ContentMain>{children}</ContentMain>
     </>
   );

--- a/next/src/routes/_layout/questionnaire.$questionnaireId/_layout-q/tcm-composition.tsx
+++ b/next/src/routes/_layout/questionnaire.$questionnaireId/_layout-q/tcm-composition.tsx
@@ -1,9 +1,22 @@
 import { createFileRoute } from '@tanstack/react-router';
+import { useTranslation } from 'react-i18next';
 
+import ContentHeader from '@/components/layout/ContentHeader';
 import { LegacyComponent } from '@/components/legacy';
 
 export const Route = createFileRoute(
   '/_layout/questionnaire/$questionnaireId/_layout-q/tcm-composition',
 )({
-  component: LegacyComponent,
+  component: RouteComponent,
 });
+
+function RouteComponent() {
+  const { t } = useTranslation();
+
+  return (
+    <>
+      <ContentHeader title={t('questionnaire.title')} />
+      <LegacyComponent />
+    </>
+  );
+}

--- a/next/src/routes/_layout/questionnaire.$questionnaireId/_layout-q/version.$versionId/codes-lists.tsx
+++ b/next/src/routes/_layout/questionnaire.$questionnaireId/_layout-q/version.$versionId/codes-lists.tsx
@@ -23,7 +23,7 @@ export const Route = createFileRoute(
     queryClient.ensureQueryData(
       codesListsFromVersionQueryOptions(questionnaireId, versionId),
     );
-    return { crumb: t('codesList.title') };
+    return { crumb: t('crumb.codesLists') };
   },
 });
 
@@ -34,7 +34,7 @@ function RouteComponent() {
   );
 
   return (
-    <ComponentWrapper codesListsCount={codesLists.length}>
+    <ComponentWrapper>
       <CodesListsOverview
         questionnaireId={questionnaireId}
         codesLists={codesLists}
@@ -54,22 +54,16 @@ function ErrorComponent({ error }: Readonly<{ error: Error }>) {
 
 function ComponentWrapper({
   children,
-  codesListsCount,
-}: Readonly<{
-  children: React.ReactNode;
-  codesListsCount?: number;
-}>) {
+}: Readonly<{ children: React.ReactNode }>) {
   const { t } = useTranslation();
   const { questionnaireId, versionId } = Route.useParams();
-
-  const codesListsAffix = codesListsCount ? `: ${codesListsCount}` : '';
 
   return (
     <>
       <ContentHeader
         isReadonly
         questionnaireId={questionnaireId}
-        title={`${t('codesList.title')} ${codesListsAffix}`}
+        title={t('codesLists.title')}
         versionId={versionId}
       />
       <ContentMain>{children}</ContentMain>

--- a/next/src/routes/_layout/questionnaire.$questionnaireId/_layout-q/version.$versionId/index.tsx
+++ b/next/src/routes/_layout/questionnaire.$questionnaireId/_layout-q/version.$versionId/index.tsx
@@ -23,7 +23,7 @@ function RouteComponent() {
       <ContentHeader
         isReadonly
         questionnaireId={questionnaireId}
-        title={t('questionnaire.title', { id: questionnaireId })}
+        title={t('questionnaire.title')}
         versionId={versionId}
       />
       <LegacyComponent />

--- a/next/src/routes/_layout/questionnaire.$questionnaireId/_layout-q/version.$versionId/nomenclatures.tsx
+++ b/next/src/routes/_layout/questionnaire.$questionnaireId/_layout-q/version.$versionId/nomenclatures.tsx
@@ -24,7 +24,7 @@ export const Route = createFileRoute(
     queryClient.ensureQueryData(
       nomenclaturesFromVersionQueryOptions(questionnaireId, versionId),
     );
-    return { crumb: t('nomenclatures.title') };
+    return { crumb: t('crumb.nomenclatures') };
   },
 });
 
@@ -35,7 +35,7 @@ function RouteComponent() {
   );
 
   return (
-    <ComponentWrapper nomenclaturesCount={data.length}>
+    <ComponentWrapper>
       <NomenclaturesOverview
         questionnaireId={questionnaireId}
         nomenclatures={data}
@@ -54,24 +54,16 @@ function ErrorComponent({ error }: Readonly<{ error: Error }>) {
 
 function ComponentWrapper({
   children,
-  nomenclaturesCount,
-}: Readonly<{
-  children: React.ReactNode;
-  nomenclaturesCount?: number;
-}>) {
+}: Readonly<{ children: React.ReactNode }>) {
   const { t } = useTranslation();
   const { questionnaireId, versionId } = Route.useParams();
-
-  const nomenclaturesAffix = nomenclaturesCount
-    ? `: ${nomenclaturesCount}`
-    : '';
 
   return (
     <>
       <ContentHeader
         isReadonly
         questionnaireId={questionnaireId}
-        title={`${t('nomenclatures.title')} ${nomenclaturesAffix}`}
+        title={t('nomenclatures.title')}
         versionId={versionId}
       />
       <ContentMain>{children}</ContentMain>

--- a/next/src/routes/_layout/questionnaire.$questionnaireId/_layout-q/version.$versionId/route.tsx
+++ b/next/src/routes/_layout/questionnaire.$questionnaireId/_layout-q/version.$versionId/route.tsx
@@ -5,6 +5,6 @@ export const Route = createFileRoute(
   '/_layout/questionnaire/$questionnaireId/_layout-q/version/$versionId',
 )({
   loader: ({ context: { t }, params: { versionId } }) => ({
-    crumb: t('version.crumb', { id: versionId }),
+    crumb: t('crumb.version', { id: versionId }),
   }),
 });

--- a/next/src/routes/_layout/questionnaire.$questionnaireId/_layout-q/versions.tsx
+++ b/next/src/routes/_layout/questionnaire.$questionnaireId/_layout-q/versions.tsx
@@ -18,7 +18,7 @@ export const Route = createFileRoute(
     params: { questionnaireId },
   }) => {
     queryClient.ensureQueryData(versionsQueryOptions(questionnaireId));
-    return { crumb: t('questionnaires.navigation.history') };
+    return { crumb: t('crumb.history') };
   },
 });
 

--- a/next/src/routes/_layout/questionnaire.$questionnaireId/route.tsx
+++ b/next/src/routes/_layout/questionnaire.$questionnaireId/route.tsx
@@ -4,7 +4,7 @@ import { createFileRoute } from '@tanstack/react-router';
 export const Route = createFileRoute('/_layout/questionnaire/$questionnaireId')(
   {
     loader: ({ context: { t }, params: { questionnaireId } }) => ({
-      crumb: t('questionnaire.title', { id: questionnaireId }),
+      crumb: t('crumb.questionnaire', { id: questionnaireId }),
     }),
   },
 );

--- a/next/src/routes/_layout/questionnaires/route.tsx
+++ b/next/src/routes/_layout/questionnaires/route.tsx
@@ -2,5 +2,5 @@ import { createFileRoute } from '@tanstack/react-router';
 
 // This is used only for the crumb part, ignore it
 export const Route = createFileRoute('/_layout/questionnaires')({
-  loader: ({ context: { t } }) => ({ crumb: t('questionnaires.title') }),
+  loader: ({ context: { t } }) => ({ crumb: t('crumb.questionnaires') }),
 });


### PR DESCRIPTION
- improve the left navigation bar responsiveness : on a small screen, we decrease its width by only displaying the buttons logo instead of logo + label
- version display in the left nav bar : replace the dropdown (for going back to the latest), by a button which is disabled if we're already on the latest
- nomenclature page : improve filters for being more like in codesList page (showing the current applied filters, and the number of nomenclatures matching the filters)
- rename overview -> questionnaire , in the left nav bar