### PR TITLE
fix: handle correctly z-index in legacy Pogues with next modal

### DIFF
--- a/next/src/components/ui/Dialog.tsx
+++ b/next/src/components/ui/Dialog.tsx
@@ -53,8 +53,8 @@ export default function Dialog({
         }
       />
       <UIDialog.Portal>
-        <UIDialog.Backdrop className="fixed inset-0 bg-black opacity-20 transition-all duration-150 data-[ending-style]:opacity-0 data-[starting-style]:opacity-0 dark:opacity-70" />
-        <UIDialog.Popup className="fixed z-500 top-1/2 left-1/2 -mt-8 w-96 max-w-[calc(100vw-3rem)] -translate-x-1/2 -translate-y-1/2 rounded-lg bg-gray-50 p-6 text-gray-900 outline outline-1 outline-gray-200 transition-all duration-150 data-[ending-style]:scale-90 data-[ending-style]:opacity-0 data-[starting-style]:scale-90 data-[starting-style]:opacity-0 dark:outline-gray-300">
+        <UIDialog.Backdrop className="fixed z-99 inset-0 bg-black opacity-20 transition-all duration-150 data-[ending-style]:opacity-0 data-[starting-style]:opacity-0 dark:opacity-70" />
+        <UIDialog.Popup className="fixed z-100 top-1/2 left-1/2 -mt-8 w-96 max-w-[calc(100vw-3rem)] -translate-x-1/2 -translate-y-1/2 rounded-lg bg-gray-50 p-6 text-gray-900 outline outline-1 outline-gray-200 transition-all duration-150 data-[ending-style]:scale-90 data-[ending-style]:opacity-0 data-[starting-style]:scale-90 data-[starting-style]:opacity-0 dark:outline-gray-300">
           <UIDialog.Title className="-mt-1.5 mb-1 text-lg font-medium">
             {title}
           </UIDialog.Title>

--- a/src/scss/inc/_generic-input.scss
+++ b/src/scss/inc/_generic-input.scss
@@ -3,7 +3,7 @@
   top: 0;
   margin-top: 20px;
   width: inherit;
-  z-index: 100;
+  z-index: 50;
   text-align: center;
   bottom: 20px;
   background-color: white;
@@ -19,7 +19,7 @@
     color: black;
   }
   body.ReactModal__Body--open & {
-    z-index: -100;
+    z-index: -50;
   }
 }
 

--- a/src/scss/inc/controls/_ctrl-input-autocomplete.scss
+++ b/src/scss/inc/controls/_ctrl-input-autocomplete.scss
@@ -13,7 +13,7 @@
     margin: 0;
     padding: 0;
     position: absolute;
-    z-index: 100;
+    z-index: 50;
     background-color: white;
     width: 95%;
     border: 1px solid grey;


### PR DESCRIPTION
Legacy toolbar was still clickable when we have a modal of next app.

Globally change z-indexes everywhere, with 100 as the maximum.
In the modal backdrop needed to be set, else default value is under every defined value