### PR TITLE
fix: date format validation

### DIFF
--- a/src/utils/validation/rules/date.ts
+++ b/src/utils/validation/rules/date.ts
@@ -16,7 +16,8 @@ const { RESPONSE_FORMAT } = TABS_PATHS;
 
 const simpleDateFormatPath = `${RESPONSE_FORMAT}.${SIMPLE}.${DATE}.format`;
 
-/** Check that a date respects a given format.
+/**
+ * Check that a date respects a given format.
  *
  * Returns the error message, or undefined if the format is respected */
 function checkDate(format: string, value?: string): string | undefined {
@@ -25,29 +26,27 @@ function checkDate(format: string, value?: string): string | undefined {
   })(value) as string | undefined;
 }
 
-/** Minimum must be scpecified and respect the format. */
+/** Rule that returns a format error if a date does not respect a specific format. */
+function checkDateRule(formatPath: string) {
+  return (value?: string, { form }: { [formatPath]?: string } = {}) => {
+    // there is a value that does not match with the date format
+    const dateFormat = get(form, formatPath) as string;
+    return value && checkDate(dateFormat, value) !== undefined
+      ? Dictionary.formatDate
+      : undefined;
+  };
+}
+
+/** Minimum must be specified and respect the format. */
 export const dateMinimumRules = (formatPath: string) => [
   (value?: string) => required(value) && Dictionary.validation_minimum,
-  (value?: string, { form }: { [formatPath]?: string } = {}) => {
-    // there is a value that does not match with the date format
-    const dateFormat = get(form, formatPath) as string;
-    return value && checkDate(dateFormat, value) !== undefined
-      ? Dictionary.formatDate
-      : undefined;
-  },
+  checkDateRule(formatPath),
 ];
 
-/** Maximum must be scpecified and respect the format. */
+/** Maximum must be specified and respect the format. */
 export const dateMaximumRules = (formatPath: string) => [
   (value?: string) => required(value) && Dictionary.validation_maximum,
-  (value?: string, { form }: { [formatPath]?: string } = {}) => {
-    // there is a value that does not match with the date format
-    const dateFormat = get(form, formatPath) as string;
-
-    return value && checkDate(dateFormat, value) !== undefined
-      ? Dictionary.formatDate
-      : undefined;
-  },
+  checkDateRule(formatPath),
 ];
 
 export const dateRules = {

--- a/src/utils/validation/rules/date.ts
+++ b/src/utils/validation/rules/date.ts
@@ -1,0 +1,48 @@
+import get from 'lodash.get';
+import { date } from 'redux-form-validators';
+
+import {
+  DATATYPE_NAME,
+  DIMENSION_TYPE,
+  QUESTION_TYPE_ENUM,
+  TABS_PATHS,
+} from '@/constants/pogues-constants';
+import Dictionary from '@/utils/dictionary/dictionary';
+
+import { required } from '../validate-rules';
+
+const { SIMPLE, TABLE } = QUESTION_TYPE_ENUM;
+const { DATE } = DATATYPE_NAME;
+const { LIST_MEASURE } = DIMENSION_TYPE;
+const { RESPONSE_FORMAT } = TABS_PATHS;
+
+const tableListDateFormat = `${RESPONSE_FORMAT}.${TABLE}.${LIST_MEASURE}.${SIMPLE}.${DATE}.format`;
+
+/** Check that a date respects a given format. */
+function checkDate(format: string, value?: string): string | undefined {
+  return date({
+    format: format.toLowerCase(),
+  })(value) as string | undefined;
+}
+
+/** Minimum must be scpecified and respect the format. */
+export const dateMinimumRules = [
+  (value?: string | number) => required(value) && Dictionary.validation_minimum,
+  (value?: string, { form }: { [tableListDateFormat]?: string } = {}) => {
+    // there is a value that does not match with the date format
+    const dateFormat = get(form, tableListDateFormat) as string;
+
+    return value && checkDate(dateFormat, value) && Dictionary.formatDate;
+  },
+];
+
+/** Maximum must be scpecified and respect the format. */
+export const dateMaximumRules = [
+  (value?: string | number) => required(value) && Dictionary.validation_maximum,
+  (value?: string, { form }: { [tableListDateFormat]?: string } = {}) => {
+    // there is a value that does not match with the date format
+    const dateFormat = get(form, tableListDateFormat) as string;
+
+    return value && checkDate(dateFormat, value) && Dictionary.formatDate;
+  },
+];

--- a/src/utils/validation/rules/date.ts
+++ b/src/utils/validation/rules/date.ts
@@ -3,7 +3,6 @@ import { date } from 'redux-form-validators';
 
 import {
   DATATYPE_NAME,
-  DIMENSION_TYPE,
   QUESTION_TYPE_ENUM,
   TABS_PATHS,
 } from '@/constants/pogues-constants';
@@ -11,14 +10,15 @@ import Dictionary from '@/utils/dictionary/dictionary';
 
 import { required } from '../validate-rules';
 
-const { SIMPLE, TABLE } = QUESTION_TYPE_ENUM;
+const { SIMPLE } = QUESTION_TYPE_ENUM;
 const { DATE } = DATATYPE_NAME;
-const { LIST_MEASURE } = DIMENSION_TYPE;
 const { RESPONSE_FORMAT } = TABS_PATHS;
 
-const tableListDateFormat = `${RESPONSE_FORMAT}.${TABLE}.${LIST_MEASURE}.${SIMPLE}.${DATE}.format`;
+const simpleDateFormatPath = `${RESPONSE_FORMAT}.${SIMPLE}.${DATE}.format`;
 
-/** Check that a date respects a given format. */
+/** Check that a date respects a given format.
+ *
+ * Returns the error message, or undefined if the format is respected */
 function checkDate(format: string, value?: string): string | undefined {
   return date({
     format: format.toLowerCase(),
@@ -26,23 +26,33 @@ function checkDate(format: string, value?: string): string | undefined {
 }
 
 /** Minimum must be scpecified and respect the format. */
-export const dateMinimumRules = [
-  (value?: string | number) => required(value) && Dictionary.validation_minimum,
-  (value?: string, { form }: { [tableListDateFormat]?: string } = {}) => {
+export const dateMinimumRules = (formatPath: string) => [
+  (value?: string) => required(value) && Dictionary.validation_minimum,
+  (value?: string, { form }: { [formatPath]?: string } = {}) => {
     // there is a value that does not match with the date format
-    const dateFormat = get(form, tableListDateFormat) as string;
-
-    return value && checkDate(dateFormat, value) && Dictionary.formatDate;
+    const dateFormat = get(form, formatPath) as string;
+    return value && checkDate(dateFormat, value) !== undefined
+      ? Dictionary.formatDate
+      : undefined;
   },
 ];
 
 /** Maximum must be scpecified and respect the format. */
-export const dateMaximumRules = [
-  (value?: string | number) => required(value) && Dictionary.validation_maximum,
-  (value?: string, { form }: { [tableListDateFormat]?: string } = {}) => {
+export const dateMaximumRules = (formatPath: string) => [
+  (value?: string) => required(value) && Dictionary.validation_maximum,
+  (value?: string, { form }: { [formatPath]?: string } = {}) => {
     // there is a value that does not match with the date format
-    const dateFormat = get(form, tableListDateFormat) as string;
+    const dateFormat = get(form, formatPath) as string;
 
-    return value && checkDate(dateFormat, value) && Dictionary.formatDate;
+    return value && checkDate(dateFormat, value) !== undefined
+      ? Dictionary.formatDate
+      : undefined;
   },
 ];
+
+export const dateRules = {
+  [`${RESPONSE_FORMAT}.${SIMPLE}.${DATE}.minimum`]:
+    dateMinimumRules(simpleDateFormatPath),
+  [`${RESPONSE_FORMAT}.${SIMPLE}.${DATE}.maximum`]:
+    dateMaximumRules(simpleDateFormatPath),
+};

--- a/src/utils/validation/rules/index.ts
+++ b/src/utils/validation/rules/index.ts
@@ -4,6 +4,7 @@ List of business rules to be applied to each questionnaire's components.
 import { calculatedVariableRules } from './calculatedVariable';
 import { collectedVariableRules } from './collectedVariable';
 import { controlRules } from './control';
+import { dateRules } from './date';
 import { declarationRules } from './declaration';
 import { durationRulesPTnHnM, durationRulesPnYnM } from './duration';
 import { externalVariableRules } from './externalVariable';
@@ -20,6 +21,7 @@ export {
   calculatedVariableRules,
   collectedVariableRules,
   controlRules,
+  dateRules,
   declarationRules,
   durationRulesPTnHnM,
   durationRulesPnYnM,

--- a/src/utils/validation/rules/question.ts
+++ b/src/utils/validation/rules/question.ts
@@ -42,8 +42,6 @@ export const questionRules = {
   [`${RESPONSE_FORMAT}.${SIMPLE}.${NUMERIC}.maximum`]: [required],
 
   [`${RESPONSE_FORMAT}.${SIMPLE}.${DATE}.format`]: [requiredSelect],
-  [`${RESPONSE_FORMAT}.${SIMPLE}.${DATE}.minimum`]: [required],
-  [`${RESPONSE_FORMAT}.${SIMPLE}.${DATE}.maximum`]: [required],
 
   // for single response suggester, we need to select a nomenclature
   [`${RESPONSE_FORMAT}.${SINGLE_CHOICE}.${DEFAULT_NOMENCLATURE_SELECTOR_PATH}.id`]:

--- a/src/utils/validation/rules/tableListMeasures.ts
+++ b/src/utils/validation/rules/tableListMeasures.ts
@@ -11,6 +11,7 @@ import {
 import Dictionary from '@/utils/dictionary/dictionary';
 
 import { minValue, required, requiredSelect } from '../validate-rules';
+import { dateMaximumRules, dateMinimumRules } from './date';
 import { minutesRules, monthsRules } from './duration';
 
 const { SIMPLE, SINGLE_CHOICE, TABLE } = QUESTION_TYPE_ENUM;
@@ -69,19 +70,16 @@ export const tableListMeasuresRules = {
         required(value) && Dictionary.validation_minimum,
     ],
 
-  /* Date measure must have format / minimum / maximum. */
+  /* Date measure must have format. */
   [`${RESPONSE_FORMAT}.${TABLE}.${LIST_MEASURE}.${SIMPLE}.${DATE}.format`]: [
     (value?: string | string[]) =>
       requiredSelect(value) && Dictionary.validation_format,
   ],
-  [`${RESPONSE_FORMAT}.${TABLE}.${LIST_MEASURE}.${SIMPLE}.${DATE}.minimum`]: [
-    (value?: string | number) =>
-      required(value) && Dictionary.validation_minimum,
-  ],
-  [`${RESPONSE_FORMAT}.${TABLE}.${LIST_MEASURE}.${SIMPLE}.${DATE}.maximum`]: [
-    (value?: string | number) =>
-      required(value) && Dictionary.validation_maximum,
-  ],
+
+  [`${RESPONSE_FORMAT}.${TABLE}.${LIST_MEASURE}.${SIMPLE}.${DATE}.minimum`]:
+    dateMinimumRules,
+  [`${RESPONSE_FORMAT}.${TABLE}.${LIST_MEASURE}.${SIMPLE}.${DATE}.maximum`]:
+    dateMaximumRules,
 
   /* Duration measure must have format / minimum / maximum. */
   [tableListDurationFormat]: [

--- a/src/utils/validation/rules/tableListMeasures.ts
+++ b/src/utils/validation/rules/tableListMeasures.ts
@@ -21,6 +21,7 @@ const { RESPONSE_FORMAT } = TABS_PATHS;
 
 const tableListSingleChoiceVisHint = `${RESPONSE_FORMAT}.${TABLE}.${LIST_MEASURE}.${SINGLE_CHOICE}.visHint`;
 const tableListDurationFormat = `${RESPONSE_FORMAT}.${TABLE}.${LIST_MEASURE}.${SIMPLE}.${DURATION}.format`;
+const tableListDateFormat = `${RESPONSE_FORMAT}.${TABLE}.${LIST_MEASURE}.${SIMPLE}.${DATE}.format`;
 
 export const tableListMeasuresRules = {
   [`${RESPONSE_FORMAT}.${TABLE}.${LIST_MEASURE}.label`]: [
@@ -77,9 +78,9 @@ export const tableListMeasuresRules = {
   ],
 
   [`${RESPONSE_FORMAT}.${TABLE}.${LIST_MEASURE}.${SIMPLE}.${DATE}.minimum`]:
-    dateMinimumRules,
+    dateMinimumRules(tableListDateFormat),
   [`${RESPONSE_FORMAT}.${TABLE}.${LIST_MEASURE}.${SIMPLE}.${DATE}.maximum`]:
-    dateMaximumRules,
+    dateMaximumRules(tableListDateFormat),
 
   /* Duration measure must have format / minimum / maximum. */
   [tableListDurationFormat]: [

--- a/src/utils/validation/validate.js
+++ b/src/utils/validation/validate.js
@@ -15,6 +15,7 @@ import {
   calculatedVariableRules,
   collectedVariableRules,
   controlRules,
+  dateRules,
   declarationRules,
   durationRulesPTnHnM,
   durationRulesPnYnM,
@@ -40,17 +41,25 @@ export function validateQuestionnaireForm(values, setErrors) {
 }
 
 const { SIMPLE } = QUESTION_TYPE_ENUM;
-const { DURATION } = DATATYPE_NAME;
+const { DATE, DURATION } = DATATYPE_NAME;
 const { RESPONSE_FORMAT } = TABS_PATHS;
 
 export function validateQuestionForm(values, setErrors, codesListsStore) {
   let errors;
 
+  const dateFormat = get(values, `${RESPONSE_FORMAT}.${SIMPLE}.${DATE}.format`);
+
   const durationFormat = get(
     values,
     `${RESPONSE_FORMAT}.${SIMPLE}.${DURATION}.format`,
   );
-  if (durationFormat === 'PTnHnM') {
+  if (dateFormat) {
+    errors = validate(
+      values,
+      { ...questionRules, ...dateRules },
+      { codesListsStore },
+    );
+  } else if (durationFormat === 'PTnHnM') {
     errors = validate(
       values,
       { ...questionRules, ...durationRulesPTnHnM },


### PR DESCRIPTION
Fix 2 bugs : 
- in a table, it was possible to validate a measure date with an incorrect format of min/max (there was an error message but you could validate)
- in a simple question date, it was possible to validate the question with an incorrect format of min/max (there was an error message but you could validate)