### PR TITLE
fix(legacy): loop validation with fixed length

### DIFF
--- a/src/utils/validation/rules/loop.ts
+++ b/src/utils/validation/rules/loop.ts
@@ -10,19 +10,26 @@ export const loopRules = {
   initialMember: [required],
   finalMember: [required],
   // we need a minimum only if the loop has a dynamic length
-  minimum: [isRequiredIfFixedLength],
+  minimum: [isRequiredWithFixedLength(false)],
   // we need a maximum only if the loop has a dynamic length
-  maximum: [isRequiredIfFixedLength],
+  maximum: [isRequiredWithFixedLength(false)],
   // we need a minimum only if the loop has a fixed length
-  size: [isRequiredIfFixedLength],
+  size: [isRequiredWithFixedLength(true)],
 };
 
-/** Apply the required rule if the loop has a fixed length. */
-function isRequiredIfFixedLength(
-  value: string | number,
-  { form }: { form: { basedOn?: string; isFixedLength?: boolean } },
-) {
-  const basedOn = get(form, 'basedOn');
-  const isFixedLength = get(form, 'isFixedLength');
-  return !basedOn && isFixedLength ? required(value) : undefined;
+/** Apply the required rule if loop is not based on, depending on fixedLength. */
+function isRequiredWithFixedLength(needsFixedLength: boolean) {
+  return (
+    value: string | number,
+    { form }: { form: { basedOn?: string; isFixedLength?: boolean } },
+  ) => {
+    const basedOn = get(form, 'basedOn');
+    const isFixedLength = get(form, 'isFixedLength');
+
+    if (!basedOn && isFixedLength === needsFixedLength) {
+      return required(value);
+    }
+
+    return undefined;
+  };
 }


### PR DESCRIPTION
In loop form, min/max should be required only if the loop has a dynamic length (currently it was required when fixed length)