### PR TITLE
feat: remove questionnaires link from header

### DIFF
--- a/next/src/components/layout/Header.test.tsx
+++ b/next/src/components/layout/Header.test.tsx
@@ -39,18 +39,6 @@ describe('Header', () => {
     expect(screen.getByText('v1.2.3')).toBeInTheDocument();
   });
 
-  it('renders a link to questionnaires page', async () => {
-    await waitFor(() => renderWithRouter(<Header user={user} />));
-
-    screen.debug();
-
-    const questionnairesLink = screen.getByRole('link', {
-      name: 'Questionnaires',
-    });
-    expect(questionnairesLink).toBeInTheDocument();
-    expect(questionnairesLink).toHaveAttribute('href', '/questionnaires');
-  });
-
   it('renders the documentation external link with icon', async () => {
     await waitFor(() => renderWithRouter(<Header user={user} />));
 

--- a/next/src/components/layout/Header.tsx
+++ b/next/src/components/layout/Header.tsx
@@ -30,7 +30,6 @@ export default function Header({ user }: Readonly<HeaderProps>) {
         <div className="text-sm">v{appVersion}</div>
       </div>
       <div className="flex justify-center gap-x-15">
-        <Link to="/questionnaires">{t('common.questionnaires')}</Link>
         <a
           className="flex items-center hover:underline gap-x-1"
           href="https://inseefr.github.io/Bowie/1._Pogues/"


### PR DESCRIPTION
The "questionnaires" link in the header seems redundant since we have the "homepage" button in the sidebar (which redirect to the questionnaires page).