### PR TITLE
feat: remove header avatar when user is not logged in

### DIFF
--- a/next/src/components/layout/User.tsx
+++ b/next/src/components/layout/User.tsx
@@ -24,26 +24,18 @@ export default function User({ user }: Readonly<UserProps>) {
       redirectTo: 'home',
     });
   }
-  return (
+
+  return isUserLoggedIn ? (
     <Menu
       items={[
-        !isUserLoggedIn
-          ? {
-              label: t('common.login'),
-              icon: <LogoutIcon />,
-              onClick: () => {
-                // Not active yet, button will be set later
-              },
-              disabled: true,
-            }
-          : {
-              label: t('common.logout'),
-              icon: <LogoutIcon />,
-              onClick: onLogout,
-            },
+        {
+          label: t('common.logout'),
+          icon: <LogoutIcon />,
+          onClick: onLogout,
+        },
       ]}
     >
       <Avatar initials={initials} />
     </Menu>
-  );
+  ) : null;
 }

--- a/next/src/routes/_layout/login.tsx
+++ b/next/src/routes/_layout/login.tsx
@@ -1,7 +1,5 @@
 import { createFileRoute, useNavigate } from '@tanstack/react-router';
-import { useTranslation } from 'react-i18next';
 
-import ContentHeader from '@/components/layout/ContentHeader';
 import ContentMain from '@/components/layout/ContentMain';
 import Login from '@/components/login/Login';
 import { useOidc } from '@/contexts/oidc';
@@ -15,7 +13,6 @@ export const Route = createFileRoute('/_layout/login')({
 });
 
 function RouteComponent() {
-  const { t } = useTranslation();
   const navigate = useNavigate();
   const { isUserLoggedIn } = useOidc();
 
@@ -24,11 +21,8 @@ function RouteComponent() {
   }
 
   return (
-    <>
-      <ContentHeader title={t('common.login')} />
-      <ContentMain>
-        <Login />
-      </ContentMain>
-    </>
+    <ContentMain>
+      <Login />
+    </ContentMain>
   );
 }

--- a/next/src/routes/index.tsx
+++ b/next/src/routes/index.tsx
@@ -2,6 +2,6 @@ import { createFileRoute, redirect } from '@tanstack/react-router';
 
 export const Route = createFileRoute('/')({
   beforeLoad: () => {
-    throw redirect({ to: '/questionnaires' });
+    throw redirect({ to: '/login' });
   },
 });


### PR DESCRIPTION
- Removed the "avatar" part of the header when the user is logged out: it should only be displayed when one is logged in (since it will hold user-related actions).
- Removed the "Se connecter" title from the login page which was a bit useless as of now.