### PR TITLE
fix(next): roundabout variables querykey & multimode variables scope

### DIFF
--- a/next/src/api/variables.ts
+++ b/next/src/api/variables.ts
@@ -29,7 +29,7 @@ export const variablesQueryOptions = (questionnaireId: string) =>
  */
 export const roundaboutVariablesQueryOptions = (questionnaireId: string) =>
   queryOptions({
-    queryKey: variablesKeys.all(questionnaireId),
+    queryKey: variablesKeys.roundabout(questionnaireId),
     queryFn: () => getRoundaboutVariables(questionnaireId),
   });
 

--- a/next/src/components/multimode/form/IsMovedRulesForm.tsx
+++ b/next/src/components/multimode/form/IsMovedRulesForm.tsx
@@ -67,7 +67,11 @@ export default function MultimodeIsMovedRulesForm({
               label={t('multimode.form.leafFormula')}
               className="h-20"
               error={error?.message}
-              suggestionsVariables={roundaboutVariables}
+              // Warning : it should be roundaboutVariables but currently VTLEditor can't be rendered twice
+              // with different suggestionsVariables else every field has the suggestionsVariables of the last field.
+              // Until we find a solution, we prefer to use the questionnaire variables.
+
+              suggestionsVariables={variables}
               {...field}
             />
           )}


### PR DESCRIPTION
- wrong querykey for getting roundabout variables, it's currently the same as the key for getting questionnaire variables

- issue on AntlrEditor, making that we cannot have multiple editors with different suggestion variables. Until we find a real solution, on multimode form we use only the questionnaire variables even for the roundabout field