### PR TITLE
feat(next): enable to delete multimode

### DIFF
--- a/next/src/api/multimode.test.ts
+++ b/next/src/api/multimode.test.ts
@@ -4,6 +4,7 @@ import { MultimodeIsMovedRules } from '@/models/multimode';
 
 import { MultimodeDTO, MultimodeRuleName } from './models/multimodeDTO';
 import {
+  deleteMultimode,
   getMultimode,
   getMultimodeFromVersion,
   putMultimode,
@@ -65,5 +66,14 @@ it('Put multimode works', async () => {
     .reply(204);
 
   const res = await putMultimode('my-questionnaire', multimodeIsMovedRules);
+  expect(res.status).toEqual(204);
+});
+
+it('Delete multimode works', async () => {
+  nock('https://mock-api')
+    .delete('/persistence/questionnaire/my-questionnaire/multimode')
+    .reply(204);
+
+  const res = await deleteMultimode('my-questionnaire');
   expect(res.status).toEqual(204);
 });

--- a/next/src/api/multimode.ts
+++ b/next/src/api/multimode.ts
@@ -82,3 +82,12 @@ export async function putMultimode(
     { headers: { 'Content-Type': 'application/json' } },
   );
 }
+
+/** Delete multimode. */
+export async function deleteMultimode(
+  questionnaireId: string,
+): Promise<Response> {
+  return instance.delete(
+    `/persistence/questionnaire/${questionnaireId}/multimode`,
+  );
+}

--- a/next/src/components/multimode/MultimodeOverview.test.tsx
+++ b/next/src/components/multimode/MultimodeOverview.test.tsx
@@ -1,18 +1,11 @@
 import { fireEvent, waitFor } from '@testing-library/dom';
+import nock from 'nock';
 
-import { deleteMultimode } from '@/api/multimode';
 import { renderWithRouter } from '@/testing/render';
 
 import MultimodeOverview from './MultimodeOverview';
 
-// mock the API function
-vi.mock('@/api/multimode', async (importOriginal) => {
-  const actual = await importOriginal<typeof import('@/api/multimode')>();
-  return {
-    ...actual,
-    deleteMultimode: vi.fn(),
-  };
-});
+vi.mock('@/lib/auth/oidc');
 
 describe('MultimodeOverview', () => {
   it('display multimode questionnaire rule', async () => {
@@ -98,14 +91,18 @@ describe('MultimodeOverview', () => {
 
     expect(getByRole('button', { name: 'Delete' })).toBeEnabled();
 
+    const scope = nock('https://mock-api')
+      .delete('/persistence/questionnaire/q-id/multimode')
+      .reply(200);
+
     // click on delete button
     fireEvent.click(getByRole('button', { name: 'Delete' }));
     // confirm in dialog
     fireEvent.click(getByRole('button', { name: 'Validate' }));
 
+    // multimode has been deleted
     await waitFor(() => {
-      // multimode has been deleted
-      expect(deleteMultimode).toHaveBeenCalledWith('q-id');
+      expect(scope.isDone()).toBeTruthy();
     });
   });
 

--- a/next/src/components/multimode/MultimodeOverview.test.tsx
+++ b/next/src/components/multimode/MultimodeOverview.test.tsx
@@ -1,6 +1,18 @@
+import { fireEvent, waitFor } from '@testing-library/dom';
+
+import { deleteMultimode } from '@/api/multimode';
 import { renderWithRouter } from '@/testing/render';
 
 import MultimodeOverview from './MultimodeOverview';
+
+// mock the API function
+vi.mock('@/api/multimode', async (importOriginal) => {
+  const actual = await importOriginal<typeof import('@/api/multimode')>();
+  return {
+    ...actual,
+    deleteMultimode: vi.fn(),
+  };
+});
 
 describe('MultimodeOverview', () => {
   it('display multimode questionnaire rule', async () => {
@@ -76,6 +88,27 @@ describe('MultimodeOverview', () => {
     );
   });
 
+  it('allow to delete multimode rules', async () => {
+    const { getByRole } = await renderWithRouter(
+      <MultimodeOverview
+        questionnaireId="q-id"
+        isMovedRules={{ questionnaireFormula: 'my-q-formula' }}
+      />,
+    );
+
+    expect(getByRole('button', { name: 'Delete' })).toBeEnabled();
+
+    // click on delete button
+    fireEvent.click(getByRole('button', { name: 'Delete' }));
+    // confirm in dialog
+    fireEvent.click(getByRole('button', { name: 'Validate' }));
+
+    await waitFor(() => {
+      // multimode has been deleted
+      expect(deleteMultimode).toHaveBeenCalledWith('q-id');
+    });
+  });
+
   it('does not allow to update multimode rules in readonly', async () => {
     const { queryByRole } = await renderWithRouter(
       <MultimodeOverview
@@ -87,5 +120,17 @@ describe('MultimodeOverview', () => {
 
     const button = queryByRole('link', { name: 'Edit' });
     expect(button).toBeNull();
+  });
+
+  it('does not allow to delete multimode rules in readonly', async () => {
+    const { queryByRole } = await renderWithRouter(
+      <MultimodeOverview
+        questionnaireId="q-id"
+        isMovedRules={{ questionnaireFormula: 'my-q-formula' }}
+        readonly
+      />,
+    );
+
+    expect(queryByRole('button', { name: 'Delete' })).toBeNull();
   });
 });

--- a/next/src/components/multimode/MultimodeOverview.tsx
+++ b/next/src/components/multimode/MultimodeOverview.tsx
@@ -5,9 +5,8 @@ import { useTranslation } from 'react-i18next';
 import { deleteMultimode, multimodeKeys } from '@/api/multimode';
 import ButtonLink from '@/components/ui/ButtonLink';
 import Card from '@/components/ui/Card';
+import DialogButton from '@/components/ui/DialogButton';
 import type { MultimodeIsMovedRules } from '@/models/multimode';
-
-import DialogButton from '../ui/DialogButton';
 
 interface Props {
   questionnaireId: string;

--- a/next/src/components/multimode/MultimodeOverview.tsx
+++ b/next/src/components/multimode/MultimodeOverview.tsx
@@ -1,8 +1,13 @@
+import { useMutation, useQueryClient } from '@tanstack/react-query';
+import toast from 'react-hot-toast';
 import { useTranslation } from 'react-i18next';
 
+import { deleteMultimode, multimodeKeys } from '@/api/multimode';
 import ButtonLink from '@/components/ui/ButtonLink';
 import Card from '@/components/ui/Card';
 import type { MultimodeIsMovedRules } from '@/models/multimode';
+
+import DialogButton from '../ui/DialogButton';
 
 interface Props {
   questionnaireId: string;
@@ -24,8 +29,32 @@ export default function MultimodeOverview({
   readonly = false,
 }: Readonly<Props>) {
   const { t } = useTranslation();
+
+  const queryClient = useQueryClient();
+
   const hasRules =
     isMovedRules.leafFormula || isMovedRules.questionnaireFormula;
+
+  const deleteMutation = useMutation({
+    mutationFn: ({ questionnaireId }: { questionnaireId: string }) => {
+      return deleteMultimode(questionnaireId);
+    },
+    onSuccess: (_, { questionnaireId }) =>
+      queryClient.invalidateQueries({
+        queryKey: multimodeKeys.all(questionnaireId),
+      }),
+  });
+
+  function onDelete() {
+    const promise = deleteMutation.mutateAsync({
+      questionnaireId,
+    });
+    toast.promise(promise, {
+      loading: t('common.loading'),
+      success: t('multimode.delete.success'),
+      error: (err: Error) => err.toString(),
+    });
+  }
 
   return (
     <div className="space-y-6">
@@ -61,12 +90,20 @@ export default function MultimodeOverview({
             <div>{t('multimode.noLeafRule')}</div>
           )}
           {readonly ? null : (
-            <ButtonLink
-              to="/questionnaire/$questionnaireId/multimode/edit"
-              params={{ questionnaireId }}
-            >
-              {t('common.edit')}
-            </ButtonLink>
+            <div className="flex gap-x-2">
+              <ButtonLink
+                to="/questionnaire/$questionnaireId/multimode/edit"
+                params={{ questionnaireId }}
+              >
+                {t('common.edit')}
+              </ButtonLink>
+              <DialogButton
+                label={t('common.delete')}
+                title={t('multimode.delete.dialogTitle')}
+                body={t('multimode.delete.dialogConfirm')}
+                onValidate={onDelete}
+              />
+            </div>
           )}
         </Card>
       ) : readonly ? (

--- a/next/src/lib/i18n/locales/en/multimode.json
+++ b/next/src/lib/i18n/locales/en/multimode.json
@@ -1,4 +1,9 @@
 {
+  "delete": {
+    "dialogTitle": "Delete multimode rules",
+    "dialogConfirm": "Are you sure you want to delete the multimode rules?",
+    "success": "Multimode rules have been deleted"
+  },
   "description": "Multimode allows to specify rules that will trigger a change in the survey collect method from web to interviewer.",
   "edit": {
     "label": "Edit multimode rules",

--- a/next/src/lib/i18n/locales/fr/multimode.json
+++ b/next/src/lib/i18n/locales/fr/multimode.json
@@ -1,4 +1,9 @@
 {
+  "delete": {
+    "dialogTitle": "Supprimer les règles du multimode",
+    "dialogConfirm": "Êtes-vous sûr de vouloir supprimer les règles du multimode ?",
+    "success": "Les règles du multimode ont été supprimées"
+  },
   "description": "Le multimode permet de spécifier des règles à partir desquelles un questionnaire qui commence à être rempli en web va basculer sur une collecte enquêteur.",
   "edit": {
     "label": "Mettre à jour les règles du multimode",


### PR DESCRIPTION
In multimode page, add a "delete" button.

Currently if the user wants to remove its multimode rules, he needs to edit them cleaning every field.
We prefer to add this shortcut, which is also more coherent with what is done on articulation
