### PR TITLE
feat: enable only text type for external variables

### DIFF
--- a/.github/workflows/test-next.yaml
+++ b/.github/workflows/test-next.yaml
@@ -14,10 +14,17 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
-      - uses: actions/setup-node@v4
+      - name: Install pnpm
+        uses: pnpm/action-setup@v4
         with:
-          node-version: 20
-      - run: cd next && yarn && yarn test:coverage
+          version: 10
+          package_json_file: 'next/package.json'
+      - uses: actions/setup-node@v6
+        with:
+          node-version: '20'
+          cache: 'pnpm'
+          cache-dependency-path: next/pnpm-lock.yaml
+      - run: cd next && pnpm install && pnpm test:coverage
       - name: Upload coverage artifact
         uses: actions/upload-artifact@v4
         with:

--- a/next/CHANGELOG.md
+++ b/next/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Changed
+
+- An external variable can now only have a "text" type.
+
 ## [2.3.0](https://github.com/InseeFr/Pogues/releases/tag/2.3.0) - 2026-01-19
 
 ### Added

--- a/next/CHANGELOG.md
+++ b/next/CHANGELOG.md
@@ -9,7 +9,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
-- An external variable can now only have a "text" type.
+- An external variable can now only have a "text" datatype.
 
 ## [2.3.0](https://github.com/InseeFr/Pogues/releases/tag/2.3.0) - 2026-01-19
 

--- a/next/package.json
+++ b/next/package.json
@@ -1,7 +1,7 @@
 {
   "name": "pogues",
   "private": true,
-  "version": "2.3.0",
+  "version": "2.4.0-rc.external-text-only.0",
   "type": "module",
   "scripts": {
     "generate-routes": "tsr generate",

--- a/next/src/components/ui/form/Select.tsx
+++ b/next/src/components/ui/form/Select.tsx
@@ -60,7 +60,7 @@ export default function Select<T>({
           select-none
           focus-visible:outline-2 focus-visible:-outline-offset-1 focus-visible:outline-primary
           active:bg-accent data-popup-open:bg-accent
-          data-disabled:cursor-not-allowed data-disabled:opacity-50
+          data-disabled:cursor-not-allowed data-disabled:opacity-50 data-disabled:hover:bg-default
         `}
       >
         <BaseUISelect.Value />

--- a/next/src/components/ui/form/Select.tsx
+++ b/next/src/components/ui/form/Select.tsx
@@ -52,14 +52,15 @@ export default function Select<T>({
         className={`
           flex min-w-36 w-full
           text-sm text-default font-normal
-          bg-default
+          cursor-pointer
+          bg-default hover:bg-main
           items-center justify-between gap-3
           rounded-md border border-default
           pr-3 pl-3.5 py-4
           select-none
           focus-visible:outline-2 focus-visible:-outline-offset-1 focus-visible:outline-primary
           active:bg-accent data-popup-open:bg-accent
-          ${disabled ? 'cursor-not-allowed opacity-50' : 'cursor-pointer hover:bg-main'}
+          data-disabled:cursor-not-allowed data-disabled:opacity-50
         `}
       >
         <BaseUISelect.Value />

--- a/next/src/components/ui/form/Select.tsx
+++ b/next/src/components/ui/form/Select.tsx
@@ -14,6 +14,8 @@ type Props<T> = {
   defaultValue?: BaseUISelect.Root.Props<T>['defaultValue'];
   /** Currently selected value (if controlled). */
   value?: BaseUISelect.Root.Props<T>['value'];
+  /** Disable option selection. */
+  disabled?: boolean;
 };
 
 /**
@@ -36,6 +38,7 @@ export default function Select<T>({
   options = [],
   defaultValue,
   value,
+  disabled = false,
 }: Readonly<Props<T>>) {
   return (
     <BaseUISelect.Root
@@ -43,19 +46,21 @@ export default function Select<T>({
       defaultValue={defaultValue}
       value={value}
       onValueChange={onChange}
+      disabled={disabled}
     >
       <BaseUISelect.Trigger
-        className="
-          flex min-w-36 w-full cursor-pointer
+        className={`
+          flex min-w-36 w-full
           text-sm text-default font-normal
-          bg-default hover:bg-main
+          bg-default
           items-center justify-between gap-3
           rounded-md border border-default
           pr-3 pl-3.5 py-4
           select-none
           focus-visible:outline-2 focus-visible:-outline-offset-1 focus-visible:outline-primary
           active:bg-accent data-popup-open:bg-accent
-        "
+          ${disabled ? 'cursor-not-allowed opacity-50' : 'cursor-pointer hover:bg-main'}
+        `}
       >
         <BaseUISelect.Value />
         <BaseUISelect.Icon className="flex">

--- a/next/src/components/variables/edit/EditVariableForm.tsx
+++ b/next/src/components/variables/edit/EditVariableForm.tsx
@@ -76,7 +76,6 @@ export default function EditVariableForm({
       submitLabel={t('common.edit')}
       scopes={scopes}
       variables={variables}
-      isExternalDatatypeTypeNameEditable={true}
     />
   );
 }

--- a/next/src/components/variables/edit/EditVariableForm.tsx
+++ b/next/src/components/variables/edit/EditVariableForm.tsx
@@ -76,6 +76,7 @@ export default function EditVariableForm({
       submitLabel={t('common.edit')}
       scopes={scopes}
       variables={variables}
+      isExternalDatatypeTypeNameEditable={true}
     />
   );
 }

--- a/next/src/components/variables/form/VariableForm.test.tsx
+++ b/next/src/components/variables/form/VariableForm.test.tsx
@@ -126,7 +126,7 @@ describe('VariableForm', () => {
     expect(getByText('You must provide a description')).toBeDefined();
   });
 
-  it('should disable datatype.typeName select by default when variable is external', async () => {
+  it('should disable datatype selection when variable is external (it can only be text)', async () => {
     const { getByRole } = await renderWithRouter(
       <VariableForm
         questionnaireId="q-id"
@@ -136,31 +136,37 @@ describe('VariableForm', () => {
       />,
     );
 
-    const datatypeSelect = getByRole('combobox', { name: /datatype/i });
-
-    await waitFor(() => {
-      expect(datatypeSelect).toBeDisabled();
-    });
+    const datatype = getByRole('combobox', { name: /datatype/i });
+    expect(datatype).toBeDisabled();
+    expect(datatype).toHaveTextContent(/text/i);
   });
 
-  it('should disable datatype.typeName select when editing an external variable with text datatype typename', async () => {
+  it('should disable datatype selection when editing an external variable with text datatype', async () => {
     const { getByRole } = await renderWithRouter(
       <VariableForm
         questionnaireId="q-id"
         onSubmit={vi.fn()}
         submitLabel="Validate"
         scopes={new Map<string, string>()}
+        variable={{
+          type: VariableType.External,
+          name: 'VAR_EXT',
+          description: 'test external',
+          scope: '',
+          datatype: {
+            typeName: DatatypeType.Text,
+            maxLength: 249,
+          },
+        }}
       />,
     );
 
-    const datatypeSelect = getByRole('combobox', { name: /datatype/i });
-
-    await waitFor(() => {
-      expect(datatypeSelect).toBeDisabled();
-    });
+    const datatype = getByRole('combobox', { name: /datatype/i });
+    expect(datatype).toBeDisabled();
+    expect(datatype).toHaveTextContent(/text/i);
   });
 
-  it('should allow as datatype options text/date/numeric/boolean for a calculated variable', async () => {
+  it('should allow all datatype options calculated variables', async () => {
     const { findAllByRole, getByRole } = await renderWithRouter(
       <VariableForm
         questionnaireId="q-id"
@@ -187,14 +193,13 @@ describe('VariableForm', () => {
 
     // open select
     fireEvent.click(datatypeSelect);
-    const options = await findAllByRole('option');
 
     // allowed options : text, date, numeric, boolean
-    expect(options).toHaveLength(4);
-    expect(options[0]).toHaveTextContent(/text/i);
-    expect(options[1]).toHaveTextContent(/date/i);
-    expect(options[2]).toHaveTextContent(/number/i);
-    expect(options[3]).toHaveTextContent(/boolean/i);
+    expect(await findAllByRole('option')).toHaveLength(4);
+    expect(getByRole('option', { name: /text/i })).toBeInTheDocument();
+    expect(getByRole('option', { name: /date/i })).toBeInTheDocument();
+    expect(getByRole('option', { name: /number/i })).toBeInTheDocument();
+    expect(getByRole('option', { name: /boolean/i })).toBeInTheDocument();
   });
 
   it('should allow only Text + current datatype option when editing an external variable if current datatype typename is not text', async () => {
@@ -224,11 +229,10 @@ describe('VariableForm', () => {
 
     // open select
     fireEvent.click(datatypeSelect);
-    const options = await findAllByRole('option');
 
     // allowed options : text and current variable datatype typeName
-    expect(options).toHaveLength(2);
-    expect(options[0]).toHaveTextContent(/text/i);
-    expect(options[1]).toHaveTextContent(/number/i);
+    expect(await findAllByRole('option')).toHaveLength(2);
+    expect(getByRole('option', { name: /text/i })).toBeInTheDocument();
+    expect(getByRole('option', { name: /number/i })).toBeInTheDocument();
   });
 });

--- a/next/src/components/variables/form/VariableForm.test.tsx
+++ b/next/src/components/variables/form/VariableForm.test.tsx
@@ -143,6 +143,23 @@ describe('VariableForm', () => {
     });
   });
 
+  it('should disable datatype.typeName select when editing an external variable with text datatype typename', async () => {
+    const { getByRole } = await renderWithRouter(
+      <VariableForm
+        questionnaireId="q-id"
+        onSubmit={vi.fn()}
+        submitLabel="Validate"
+        scopes={new Map<string, string>()}
+      />,
+    );
+
+    const datatypeSelect = getByRole('combobox', { name: /datatype/i });
+
+    await waitFor(() => {
+      expect(datatypeSelect).toBeDisabled();
+    });
+  });
+
   it('should allow as datatype options text/date/numeric/boolean for a calculated variable', async () => {
     const { findAllByRole, getByRole } = await renderWithRouter(
       <VariableForm
@@ -150,7 +167,6 @@ describe('VariableForm', () => {
         onSubmit={vi.fn()}
         submitLabel="Validate"
         scopes={new Map<string, string>()}
-        isExternalDatatypeTypeNameEditable
         variable={{
           type: VariableType.Calculated,
           name: 'VAR_CALC',
@@ -181,14 +197,13 @@ describe('VariableForm', () => {
     expect(options[3]).toHaveTextContent(/boolean/i);
   });
 
-  it('should allow only Text + current datatype option for an external variable when editable', async () => {
+  it('should allow only Text + current datatype option when editing an external variable if current datatype typename is not text', async () => {
     const { findAllByRole, getByRole } = await renderWithRouter(
       <VariableForm
         questionnaireId="q-id"
         onSubmit={vi.fn()}
         submitLabel="Validate"
         scopes={new Map<string, string>()}
-        isExternalDatatypeTypeNameEditable
         variable={{
           type: VariableType.External,
           name: 'VAR_EXT',

--- a/next/src/components/variables/form/VariableForm.test.tsx
+++ b/next/src/components/variables/form/VariableForm.test.tsx
@@ -1,5 +1,7 @@
 import { fireEvent, screen, waitFor, within } from '@testing-library/react';
 
+import { DatatypeType } from '@/models/datatype';
+import { VariableType } from '@/models/variables';
 import { renderWithRouter } from '@/testing/render';
 
 import VariableForm from './VariableForm';
@@ -122,5 +124,96 @@ describe('VariableForm', () => {
 
     expect(await findAllByRole('alert')).toHaveLength(1);
     expect(getByText('You must provide a description')).toBeDefined();
+  });
+
+  it('should disable datatype.typeName select by default when variable is external', async () => {
+    const { getByRole } = await renderWithRouter(
+      <VariableForm
+        questionnaireId="q-id"
+        onSubmit={vi.fn()}
+        submitLabel="Validate"
+        scopes={new Map<string, string>()}
+      />,
+    );
+
+    const datatypeSelect = getByRole('combobox', { name: /datatype/i });
+
+    await waitFor(() => {
+      expect(datatypeSelect).toBeDisabled();
+    });
+  });
+
+  it('should allow as datatype options text/date/numeric/boolean for a calculated variable', async () => {
+    const { findAllByRole, getByRole } = await renderWithRouter(
+      <VariableForm
+        questionnaireId="q-id"
+        onSubmit={vi.fn()}
+        submitLabel="Validate"
+        scopes={new Map<string, string>()}
+        isExternalDatatypeTypeNameEditable
+        variable={{
+          type: VariableType.Calculated,
+          name: 'VAR_CALC',
+          description: 'test calculated',
+          scope: '',
+          datatype: {
+            typeName: DatatypeType.Numeric,
+            minimum: 0,
+            maximum: 10,
+            decimals: 0,
+          },
+        }}
+      />,
+    );
+
+    const datatypeSelect = getByRole('combobox', { name: /datatype/i });
+    expect(datatypeSelect).toBeEnabled();
+
+    // open select
+    fireEvent.click(datatypeSelect);
+    const options = await findAllByRole('option');
+
+    // allowed options : text, date, numeric, boolean
+    expect(options).toHaveLength(4);
+    expect(options[0]).toHaveTextContent(/text/i);
+    expect(options[1]).toHaveTextContent(/date/i);
+    expect(options[2]).toHaveTextContent(/number/i);
+    expect(options[3]).toHaveTextContent(/boolean/i);
+  });
+
+  it('should allow only Text + current datatype option for an external variable when editable', async () => {
+    const { findAllByRole, getByRole } = await renderWithRouter(
+      <VariableForm
+        questionnaireId="q-id"
+        onSubmit={vi.fn()}
+        submitLabel="Validate"
+        scopes={new Map<string, string>()}
+        isExternalDatatypeTypeNameEditable
+        variable={{
+          type: VariableType.External,
+          name: 'VAR_EXT',
+          description: 'test external',
+          scope: '',
+          datatype: {
+            typeName: DatatypeType.Numeric,
+            minimum: 0,
+            maximum: 10,
+            decimals: 0,
+          },
+        }}
+      />,
+    );
+
+    const datatypeSelect = getByRole('combobox', { name: /datatype/i });
+    expect(datatypeSelect).toBeEnabled();
+
+    // open select
+    fireEvent.click(datatypeSelect);
+    const options = await findAllByRole('option');
+
+    // allowed options : text and current variable datatype typeName
+    expect(options).toHaveLength(2);
+    expect(options[0]).toHaveTextContent(/text/i);
+    expect(options[1]).toHaveTextContent(/number/i);
   });
 });

--- a/next/src/components/variables/form/VariableForm.tsx
+++ b/next/src/components/variables/form/VariableForm.tsx
@@ -30,6 +30,8 @@ type Props = {
   scopes: Map<string, string>;
   /** List of variables used for auto-completion in VTL editor. */
   variables?: Variable[];
+  /** Disable datatype selection for external variables */
+  isExternalDatatypeTypeNameEditable?: boolean;
 };
 
 /**
@@ -54,6 +56,7 @@ export default function VariableForm({
   submitLabel,
   scopes,
   variables = [],
+  isExternalDatatypeTypeNameEditable = false,
 }: Readonly<Props>) {
   const navigate = useNavigate();
 
@@ -71,6 +74,21 @@ export default function VariableForm({
 
   const selectedType = watch('type');
   const selectedTypeName = watch('datatype.typeName');
+
+  const isDatatypeTypeNameDisabled =
+    selectedType === VariableType.External &&
+    !isExternalDatatypeTypeNameEditable;
+
+  const datatypeTypeNameOptions = (() => {
+    // For External variable, enable only current saved option and 'Text'
+    if (selectedType === VariableType.External) {
+      return datatypeOptions.filter(
+        ({ value }) =>
+          value === DatatypeType.Text || value === variable.datatype.typeName,
+      );
+    }
+    return datatypeOptions;
+  })();
 
   /** Ignore dirty state and return to the variables page. */
   const handleCancel = () => {
@@ -271,9 +289,10 @@ export default function VariableForm({
             touched={isTouched}
           >
             <Select<DatatypeType>
-              options={datatypeOptions}
+              options={datatypeTypeNameOptions}
               value={value}
               onChange={onChange}
+              disabled={isDatatypeTypeNameDisabled}
             />
           </Field>
         )}

--- a/next/src/components/variables/form/VariableForm.tsx
+++ b/next/src/components/variables/form/VariableForm.tsx
@@ -30,8 +30,6 @@ type Props = {
   scopes: Map<string, string>;
   /** List of variables used for auto-completion in VTL editor. */
   variables?: Variable[];
-  /** Disable datatype selection for external variables */
-  isExternalDatatypeTypeNameEditable?: boolean;
 };
 
 /**
@@ -56,7 +54,6 @@ export default function VariableForm({
   submitLabel,
   scopes,
   variables = [],
-  isExternalDatatypeTypeNameEditable = false,
 }: Readonly<Props>) {
   const navigate = useNavigate();
 
@@ -77,7 +74,7 @@ export default function VariableForm({
 
   const isDatatypeTypeNameDisabled =
     selectedType === VariableType.External &&
-    !isExternalDatatypeTypeNameEditable;
+    variable.datatype.typeName === DatatypeType.Text;
 
   const datatypeTypeNameOptions = (() => {
     // For External variable, enable only current saved option and 'Text'


### PR DESCRIPTION
- When creating an external variable, datatype is now "text" and cannot be changed
- We do not change the existing external variables. So when editing an external variable, if its type is not "text", the user can keep the current type or change it to "text"