### PR TITLE
fix: codesList form crashes when form errors

### DIFF
--- a/next/CHANGELOG.md
+++ b/next/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+
+- CodesList form does not crash anymore when editing a codesList having VTL errors.
+
 ## [2.4.0](https://github.com/InseeFr/Pogues/releases/tag/2.4.0) - 2026-02-24
 
 ### Changed

--- a/next/package.json
+++ b/next/package.json
@@ -1,7 +1,7 @@
 {
   "name": "pogues",
   "private": true,
-  "version": "2.4.0",
+  "version": "2.4.1-rc-codes-list-form-crash.0",
   "type": "module",
   "scripts": {
     "generate-routes": "tsr generate",

--- a/next/src/components/codesLists/form/CodesListForm.tsx
+++ b/next/src/components/codesLists/form/CodesListForm.tsx
@@ -316,6 +316,7 @@ function CodesField({
           parentName={`${namePrefix}.codes`}
           subCodeIteration={subCodeIteration + 1}
           trigger={trigger}
+          setError={setError}
         />
       ))}
     </>


### PR DESCRIPTION
missing prop for setting VTL errors in codesList form, since #1117 , making form crash when there are errors