### PR TITLE
fix(legacy): crash when codeList not in store

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,7 +9,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
-- Questionnaire can now be loaded if a question uses a code list (or nomenclature) that does not exist anymore. It can happen if an existing question used a previous version of a nomenclature.
+- Questionnaire loading no longer crash when a question uses a code list (or nomenclature) that does not exist anymore. It could happen when an existing question used a previous version of a nomenclature.
 
 ### Changed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+
+- Questionnaire can now be loaded if a question uses a code list (or nomenclature) that does not exist anymore. It can happen if an existing question used a previous version of a nomenclature.
+
 ### Changed
 
 - Updated nomenclatures:

--- a/legacy/src/model/transformations/collected-variable.jsx
+++ b/legacy/src/model/transformations/collected-variable.jsx
@@ -95,7 +95,7 @@ export function remoteToStore(
       choiceType,
       codeListReference: CodeListReference,
       codeListReferenceLabel: CodeListReference
-        ? codesListsStore[CodeListReference].label
+        ? (codesListsStore[CodeListReference]?.label ?? '')
         : '',
       variableReference: VariableReference,
       variableReferenceLabel: VariableReference

--- a/legacy/src/model/transformations/collected-variable.spec.jsx
+++ b/legacy/src/model/transformations/collected-variable.spec.jsx
@@ -302,6 +302,46 @@ describe('collected variable tranformations', () => {
         ),
       ).toEqual(output);
     });
+
+    test('should handle CodeListReference not in codesListsStore', () => {
+      const input = [
+        {
+          id: 'test-id',
+          Name: 'TEST_VAR',
+          Label: 'Test Variable',
+          type: 'CollectedVariableType',
+          CodeListReference: 'non-existent-id',
+          Datatype: {
+            typeName: TEXT,
+            MaxLength: 100,
+          },
+        },
+      ];
+      const responsesByVariable = { 'test-id': {} };
+      const codesListsStore = {}; // 'non-existent-id' is not in this store
+      const output = {
+        'test-id': {
+          id: 'test-id',
+          name: 'TEST_VAR',
+          label: 'Test Variable',
+          type: TEXT,
+          choiceType: 'CODE_LIST',
+          codeListReference: 'non-existent-id',
+          codeListReferenceLabel: '', // empty label since it cannot be retrieved from codesListsStore
+          variableReferenceLabel: '',
+          [TEXT]: {
+            maxLength: 100,
+          },
+          arbitraryVariableOfVariableId: undefined,
+          mesureLevel: undefined,
+          variableReference: undefined,
+          z: undefined,
+        },
+      };
+      expect(
+        remoteToStore(input, responsesByVariable, codesListsStore),
+      ).toEqual(output);
+    });
   });
   describe('remoteToComponentState', () => {
     test('should return the state representation of a collected variable', () => {


### PR DESCRIPTION
Crash when loading a questionnaire, with a question using a codeList that is not in the codesLists store in the model.
(bug added by UCQ based on a variable)

Happens currently when we have simultaneously multiple versions of a same nomenclature (since nomenclature are not well handled for now, the old versions are sometimes removed from the store in the model...)