### PR TITLE
fix: generate max length 249 for ucq (even in table) & mcq

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - Questionnaire loading no longer crash when a question uses a code list (or nomenclature) that does not exist anymore. It could happen when an existing question used a previous version of a nomenclature.
 - nginx.conf: disable cache on remote-entry (to ensure keeping last legacy version)
+- For unique choice questions (inside or outside a table) and multiple choice questions, the variable max length is now 249 instead of 1.
 
 ### Changed
 

--- a/legacy/src/model/transformations/component.spec.jsx
+++ b/legacy/src/model/transformations/component.spec.jsx
@@ -532,7 +532,7 @@ describe('component tranformations', () => {
                   Datatype: {
                     typeName: 'TEXT',
                     type: 'TextDatatypeType',
-                    MaxLength: 1,
+                    MaxLength: 249,
                     visualizationHint: 'DROPDOWN',
                   },
                   id: 'my-q-pairwise-response-id',

--- a/legacy/src/model/transformations/questionnaire.spec.jsx
+++ b/legacy/src/model/transformations/questionnaire.spec.jsx
@@ -304,7 +304,7 @@ describe('questionnaire', () => {
                     CodeListReference: 'jf0w3fab',
                     CollectedVariableReference: 'jf0vqq4j',
                     Datatype: {
-                      MaxLength: 1,
+                      MaxLength: 249,
                       type: 'TextDatatypeType',
                       typeName: 'TEXT',
                       visualizationHint: 'CHECKBOX',

--- a/legacy/src/model/transformations/response-format-multiple.spec.ts
+++ b/legacy/src/model/transformations/response-format-multiple.spec.ts
@@ -1,5 +1,12 @@
 import { describe, expect, it } from 'vitest';
 
+import {
+  CHOICE_TYPE,
+  DATATYPE_VIS_HINT,
+  DEFAULT_CODES_LIST_SELECTOR_PATH,
+  DIMENSION_FORMATS,
+} from '@/constants/pogues-constants';
+
 import { remoteToState, stateToRemote } from './response-format-multiple';
 
 describe('response format multiple', () => {
@@ -235,6 +242,127 @@ describe('response format multiple', () => {
             id: 'my-response-id-2',
             CollectedVariableReference: 'my-var-id-2',
             Datatype: { type: 'BooleanDatatypeType', typeName: 'BOOLEAN' },
+          },
+        ],
+      });
+    });
+
+    it('Correctly compute remote data for CODES_LIST measure type', () => {
+      const state = {
+        mandatory: true,
+        PRIMARY: { CodesList: { id: 'my-cl-id' } },
+        MEASURE: {
+          type: DIMENSION_FORMATS.CODES_LIST,
+          [DIMENSION_FORMATS.CODES_LIST]: {
+            [DEFAULT_CODES_LIST_SELECTOR_PATH]: { id: 'codes-list-id' },
+            choiceType: CHOICE_TYPE.CODE_LIST,
+            visHint: DATATYPE_VIS_HINT.RADIO,
+          },
+        },
+      };
+      const collectedVariables = ['my-var-id-1', 'my-var-id-2'];
+      const collectedVariablesStore = {
+        'my-var-id-2': {
+          BOOLEAN: {},
+          DATE: undefined,
+          DURATION: undefined,
+          NUMERIC: undefined,
+          TEXT: { maxLength: 249 },
+          codeListReference: 'codes-list-id',
+          codeListReferenceLabel: 'codes-list-label',
+          id: 'my-var-id-2',
+          isCollected: '1',
+          label: '2 - lib2',
+          mesureLevel: undefined,
+          name: 'QUESTIONTA2',
+          type: 'TEXT',
+          x: 2,
+          y: Number.NaN,
+          z: undefined,
+        },
+        'my-var-id-1': {
+          BOOLEAN: {},
+          DATE: undefined,
+          DURATION: undefined,
+          NUMERIC: undefined,
+          TEXT: { maxLength: 249 },
+          codeListReference: 'codes-list-id',
+          codeListReferenceLabel: 'codes-list-label',
+          id: 'my-var-id-1',
+          isCollected: '1',
+          label: '1 - lib1',
+          mesureLevel: undefined,
+          name: 'QUESTIONTA1',
+          type: 'TEXT',
+          x: 1,
+          y: Number.NaN,
+          z: undefined,
+        },
+      };
+      const response = [
+        {
+          CollectedVariableReference: 'my-var-id-1',
+          Datatype: {
+            typeName: 'TEXT',
+            type: 'TextDatatypeType',
+          },
+          id: 'my-response-id-1',
+        },
+        {
+          CollectedVariableReference: 'my-var-id-2',
+          Datatype: {
+            typeName: 'TEXT',
+            type: 'TextDatatypeType',
+          },
+          id: 'my-response-id-2',
+        },
+      ];
+
+      const output = stateToRemote(
+        state,
+        collectedVariables,
+        collectedVariablesStore,
+        response,
+      );
+
+      expect(output).toEqual({
+        Attribute: [],
+        Dimension: [
+          {
+            CodeListReference: 'my-cl-id',
+            dimensionType: 'PRIMARY',
+            dynamic: 'NON_DYNAMIC',
+          },
+          { dimensionType: 'MEASURE' },
+        ],
+        Mapping: [
+          { MappingSource: 'my-response-id-1', MappingTarget: '1' },
+          { MappingSource: 'my-response-id-2', MappingTarget: '2' },
+        ],
+        Response: [
+          {
+            id: 'my-response-id-1',
+            CollectedVariableReference: 'my-var-id-1',
+            Datatype: {
+              type: 'TextDatatypeType',
+              typeName: 'TEXT',
+              MaxLength: 249,
+              visualizationHint: DATATYPE_VIS_HINT.RADIO,
+            },
+            choiceType: CHOICE_TYPE.CODE_LIST,
+            CodeListReference: 'codes-list-id',
+          },
+          {
+            id: 'my-response-id-2',
+            CollectedVariableReference: 'my-var-id-2',
+            Datatype: {
+              type: 'TextDatatypeType',
+              typeName: 'TEXT',
+              MaxLength: 249,
+              visualizationHint: DATATYPE_VIS_HINT.RADIO,
+            },
+            choiceType: CHOICE_TYPE.CODE_LIST,
+            CodeListReference: 'codes-list-id',
           },
         ],
       });

--- a/legacy/src/model/transformations/response-format-multiple.ts
+++ b/legacy/src/model/transformations/response-format-multiple.ts
@@ -161,7 +161,7 @@ export function stateToRemote(
       typeName: DATATYPE_NAME.TEXT,
       visHint,
       choiceType,
-      maxLength: 1,
+      maxLength: 249,
     };
   } else {
     responseState = {

--- a/legacy/src/model/transformations/response-format-single.spec.ts
+++ b/legacy/src/model/transformations/response-format-single.spec.ts
@@ -117,7 +117,7 @@ describe('stateToRemote', () => {
           CodeListReference: 'my-cl-id',
           CollectedVariableReference: 'my-var-id',
           Datatype: {
-            MaxLength: 1,
+            MaxLength: 249,
             type: 'TextDatatypeType',
             typeName: 'TEXT',
             visualizationHint: 'RADIO',
@@ -147,7 +147,7 @@ describe('stateToRemote', () => {
           CodeListReference: 'my-cl-id',
           CollectedVariableReference: 'my-var-id',
           Datatype: {
-            MaxLength: 1,
+            MaxLength: 249,
             type: 'TextDatatypeType',
             typeName: 'TEXT',
             visualizationHint: 'SUGGESTER',
@@ -177,7 +177,7 @@ describe('stateToRemote', () => {
           VariableReference: 'my-variable-id',
           CollectedVariableReference: 'my-var-id',
           Datatype: {
-            MaxLength: 1,
+            MaxLength: 249,
             type: 'TextDatatypeType',
             typeName: 'TEXT',
             visualizationHint: 'RADIO',

--- a/legacy/src/model/transformations/response-format-single.ts
+++ b/legacy/src/model/transformations/response-format-single.ts
@@ -146,7 +146,7 @@ export function stateToRemote(
         nomenclatureId,
         variableReferenceId,
         typeName: DATATYPE_NAME.TEXT,
-        maxLength: 1,
+        maxLength: 249,
         collectedVariable: collectedVariables[0],
       }),
     ],

--- a/legacy/src/model/transformations/response-format-table.jsx
+++ b/legacy/src/model/transformations/response-format-table.jsx
@@ -378,7 +378,7 @@ function stateToResponseState(state, primaryType) {
       nomenclatureId,
       variableReferenceId,
       typeName: TEXT,
-      maxLength: 1,
+      maxLength: 249,
       visHint,
       choiceType,
     };

--- a/legacy/src/model/transformations/response-format-table.spec.jsx
+++ b/legacy/src/model/transformations/response-format-table.spec.jsx
@@ -647,7 +647,7 @@ describe('stateToRemote', () => {
     const state = {
       PRIMARY: {
         type: 'CODES_LIST',
-        CODES_LIST: { CodesList: { id: 'jf0vbzj9' } },
+        CODES_LIST: { CodesList: { id: 'jf0vbzj9', label: 'my-code-list-1' } },
       },
       LIST_MEASURE: [
         {
@@ -658,8 +658,12 @@ describe('stateToRemote', () => {
         },
         {
           label: 'measure 2',
-          type: 'SIMPLE',
-          SIMPLE: { type: 'TEXT', TEXT: { maxLength: 249 } },
+          type: 'SINGLE_CHOICE',
+          SINGLE_CHOICE: {
+            CodesList: { id: 'mlz1qdq0', label: 'my-code-list-2' },
+            choiceType: 'CODE_LIST',
+            visHint: 'RADIO',
+          },
         },
       ],
     };
@@ -712,8 +716,8 @@ describe('stateToRemote', () => {
         DATE: { maximum: '', minimum: '', format: '' },
         BOOLEAN: {},
         isCollected: '0',
-        codeListReference: '',
-        codeListReferenceLabel: '',
+        codeListReference: 'mlz1qdq0',
+        codeListReferenceLabel: 'my-code-list-2',
       },
       jk8h32gm: {
         id: 'jk8h32gm',
@@ -728,8 +732,8 @@ describe('stateToRemote', () => {
         DATE: { maximum: '', minimum: '', format: '' },
         BOOLEAN: {},
         isCollected: '0',
-        codeListReference: '',
-        codeListReferenceLabel: '',
+        codeListReference: 'mlz1qdq0',
+        codeListReferenceLabel: 'my-code-list-2',
       },
     };
     const result = stateToRemote(
@@ -783,6 +787,7 @@ describe('stateToRemote', () => {
       expect(item.conditionFilter).toBeUndefined();
     });
 
+    // measure 1 : simple response
     expect(outputResponse[0].Datatype).toEqual({
       MaxLength: 249,
       type: 'TextDatatypeType',
@@ -796,6 +801,32 @@ describe('stateToRemote', () => {
     });
     expect(outputMapping[0].MappingTarget).toEqual('1 1');
     expect(outputMapping[1].MappingTarget).toEqual('2 1');
+
+    // measure 2 : single response (codeList, radio)
+    expect(outputResponse[2]).toEqual({
+      id: expect.anything(),
+      Datatype: {
+        typeName: 'TEXT',
+        type: 'TextDatatypeType',
+        visualizationHint: 'RADIO',
+        MaxLength: 249,
+      },
+      choiceType: 'CODE_LIST',
+      CodeListReference: 'mlz1qdq0',
+      CollectedVariableReference: 'jg4v561m',
+    });
+    expect(outputResponse[3]).toEqual({
+      id: expect.anything(),
+      Datatype: {
+        typeName: 'TEXT',
+        type: 'TextDatatypeType',
+        visualizationHint: 'RADIO',
+        MaxLength: 249,
+      },
+      choiceType: 'CODE_LIST',
+      CodeListReference: 'mlz1qdq0',
+      CollectedVariableReference: 'jk8h32gm',
+    });
   });
 
   it('works with non dynamic table, with secondary axes', () => {

--- a/legacy/src/utils/variables/collected-variables-multiple.js
+++ b/legacy/src/utils/variables/collected-variables-multiple.js
@@ -45,7 +45,7 @@ export function getCollectedVariablesMultiple(
       codeListReference: form[MEASURE][CODES_LIST].CodesList.id,
       codeListReferenceLabel: form[MEASURE][CODES_LIST].CodesList.label,
       type: TEXT,
-      [TEXT]: { maxLength: 1 },
+      [TEXT]: { maxLength: 249 },
     };
   } else {
     reponseFormatValues = {

--- a/legacy/src/utils/variables/collected-variables-multiple.spec.js
+++ b/legacy/src/utils/variables/collected-variables-multiple.spec.js
@@ -248,4 +248,87 @@ describe('getCollectedVariablesMultiple', () => {
       },
     ]);
   });
+
+  test('computes variables when typeMeasure is CODES_LIST', () => {
+    const questionName = 'questionName';
+    const form = {
+      PRIMARY: {
+        CodesList: {
+          id: 'id',
+          label: 'label',
+          codes: [
+            {
+              value: 'value1',
+              label: 'label1',
+              weight: 1,
+            },
+            {
+              value: 'value2',
+              label: 'label2',
+              weight: 2,
+            },
+          ],
+        },
+      },
+      MEASURE: {
+        type: 'CODES_LIST',
+        CODES_LIST: {
+          CodesList: {
+            id: 'codesListId',
+            label: 'codesListLabel',
+          },
+        },
+      },
+    };
+    const codesListStore = {
+      id: {
+        id: 'id',
+        label: 'label',
+        codes: [
+          {
+            value: 'value1',
+            label: 'label1',
+            weight: 1,
+          },
+          {
+            value: 'value2',
+            label: 'label2',
+            weight: 2,
+          },
+        ],
+      },
+    };
+    const result = getCollectedVariablesMultiple(
+      questionName,
+      form,
+      codesListStore,
+    );
+
+    expect(result).toEqual([
+      {
+        type: 'TEXT',
+        TEXT: { maxLength: 249 },
+        id: result[0].id,
+        name: 'questionName1',
+        label: 'value1 - label1',
+        x: 1,
+        isCollected: '1',
+        alternativeLabel: '',
+        codeListReference: 'codesListId',
+        codeListReferenceLabel: 'codesListLabel',
+      },
+      {
+        type: 'TEXT',
+        TEXT: { maxLength: 249 },
+        id: result[1].id,
+        name: 'questionName2',
+        label: 'value2 - label2',
+        x: 2,
+        isCollected: '1',
+        alternativeLabel: '',
+        codeListReference: 'codesListId',
+        codeListReferenceLabel: 'codesListLabel',
+      },
+    ]);
+  });
 });

--- a/legacy/src/utils/variables/collected-variables-single.js
+++ b/legacy/src/utils/variables/collected-variables-single.js
@@ -38,7 +38,7 @@ export function getCollectedVariablesSingle(
         variableReferenceLabel: desiredVarLabel,
         type: TEXT,
         choiceType: form.choiceType,
-        [TEXT]: { maxLength: 1 },
+        [TEXT]: { maxLength: 249 },
       },
     );
   } else {
@@ -50,7 +50,7 @@ export function getCollectedVariablesSingle(
         ...getReference(form),
         type: TEXT,
         choiceType: form.choiceType,
-        [TEXT]: { maxLength: 1 },
+        [TEXT]: { maxLength: 249 },
       },
     );
   }

--- a/legacy/src/utils/variables/collected-variables-single.spec.js
+++ b/legacy/src/utils/variables/collected-variables-single.spec.js
@@ -28,7 +28,7 @@ describe('getCollectedVariablesSingle', () => {
         codeListReferenceLabel: 'my-cl',
         choiceType: 'CODE_LIST',
         type: 'TEXT',
-        TEXT: { maxLength: 1 },
+        TEXT: { maxLength: 249 },
       },
     ]);
   });
@@ -65,7 +65,7 @@ describe('getCollectedVariablesSingle', () => {
         codeListReference: 'my-cl-id',
         codeListReferenceLabel: 'my-cl',
         type: 'TEXT',
-        TEXT: { maxLength: 1 },
+        TEXT: { maxLength: 249 },
       },
       {
         id: expect.any(String),
@@ -124,7 +124,7 @@ describe('getCollectedVariablesSingle', () => {
         codeListReferenceLabel: 'my-cl',
         choiceType: 'CODE_LIST',
         type: 'TEXT',
-        TEXT: { maxLength: 1 },
+        TEXT: { maxLength: 249 },
       },
       {
         id: 'var2',
@@ -186,7 +186,7 @@ describe('getCollectedVariablesSingle', () => {
         codeListReferenceLabel: 'my-cl',
         choiceType: 'CODE_LIST',
         type: 'TEXT',
-        TEXT: { maxLength: 1 },
+        TEXT: { maxLength: 249 },
       },
       {
         id: 'var2',
@@ -246,7 +246,7 @@ describe('getCollectedVariablesSingle', () => {
         codeListReferenceLabel: 'my-cl',
         choiceType: 'CODE_LIST',
         type: 'TEXT',
-        TEXT: { maxLength: 1 },
+        TEXT: { maxLength: 249 },
       },
     ]);
   });
@@ -269,7 +269,7 @@ describe('getCollectedVariablesSingle', () => {
         codeListReferenceLabel: 'my-nomenclature',
         choiceType: 'SUGGESTER',
         type: 'TEXT',
-        TEXT: { maxLength: 1 },
+        TEXT: { maxLength: 249 },
       },
       {
         id: expect.any(String),
@@ -301,7 +301,7 @@ describe('getCollectedVariablesSingle', () => {
         codeListReferenceLabel: 'my-nomenclature',
         choiceType: 'SUGGESTER',
         type: 'TEXT',
-        TEXT: { maxLength: 1 },
+        TEXT: { maxLength: 249 },
       },
     ]);
   });
@@ -329,7 +329,7 @@ describe('getCollectedVariablesSingle', () => {
         variableReferenceLabel: 'my-variableRef',
         choiceType: 'VARIABLE',
         type: 'TEXT',
-        TEXT: { maxLength: 1 },
+        TEXT: { maxLength: 249 },
       },
     ]);
   });

--- a/legacy/src/utils/variables/collected-variables-table.js
+++ b/legacy/src/utils/variables/collected-variables-table.js
@@ -162,7 +162,7 @@ export function getReponsesValues(measure) {
             ? measure[SINGLE_CHOICE][listPath].label
             : '',
         type: TEXT,
-        [TEXT]: { maxLength: 1 },
+        [TEXT]: { maxLength: 249 },
         variableReference:
           choiceType === CHOICE_TYPE.VARIABLE
             ? measure[SINGLE_CHOICE][listPath].id

--- a/legacy/src/utils/variables/collected-variables-table.spec.js
+++ b/legacy/src/utils/variables/collected-variables-table.spec.js
@@ -393,7 +393,7 @@ describe('getReponsesValues', () => {
       variableReferenceLabel: '',
       choiceType: 'CODE_LIST',
       type: 'TEXT',
-      TEXT: { maxLength: 1 },
+      TEXT: { maxLength: 249 },
     };
 
     expect(getReponsesValues(measure)).toEqual(output);
@@ -433,7 +433,7 @@ describe('getReponsesValues', () => {
       variableReferenceLabel: 'my-variable-label',
       choiceType: 'VARIABLE',
       type: 'TEXT',
-      TEXT: { maxLength: 1 },
+      TEXT: { maxLength: 249 },
     };
 
     expect(getReponsesValues(measure)).toEqual(output);
@@ -467,7 +467,7 @@ describe('getReponsesValues', () => {
       variableReferenceLabel: '',
       choiceType: 'CODE_LIST',
       type: 'TEXT',
-      TEXT: { maxLength: 1 },
+      TEXT: { maxLength: 249 },
     };
 
     expect(getReponsesValues(measure)).toEqual(output);

--- a/legacy/src/vite-env.d.ts
+++ b/legacy/src/vite-env.d.ts
@@ -8,6 +8,13 @@ type ImportMetaEnv = {
   VITE_OIDC_CLIENT_ID: string
   VITE_OIDC_SCOPES: string
   VITE_ENABLE_PAIRING_RECAP: string
+  VITE_ACTIVE_NAMESPACES: string
+  VITE_CUSTOMIZE_URL: string
+  VITE_TROMBI_URL: string
+  VITE_DEFAULT_USER_ID: string
+  VITE_DEFAULT_USER_NAME: string
+  VITE_DEFAULT_USER_STAMP: string
+  VITE_LOG_LEVEL: string
   BASE_URL: string
   MODE: string
   DEV: boolean


### PR DESCRIPTION
Even if the maxLength is not used in questionnaire for ucq/mcq , it can be used for validating the format of the collected variable (it is used for example for personalization).

For ucq/mcq , the maxLength was forced to 1, but it has no sense because the collected value is usually longer.

So as for text variables default value, we now force the maxLength to 249 for ucq/mcq

⚠️ We assume we don't update the existing variables in Pogues-ui. But it is correctly fixed for new variables or when regenerating existing variables