### PR TITLE
fix(nomenclatures): typos fr

### DIFF
--- a/next/src/lib/i18n/locales/fr/nomenclatures.json
+++ b/next/src/lib/i18n/locales/fr/nomenclatures.json
@@ -4,11 +4,11 @@
   "search": "Rechercher une nomenclature",
   "title": "Nomenclatures",
   "table": {
-    "id": "Nomenclature ID",
-    "label": "Label",
-    "version": "Version",
-    "referenceYear": "Millesime",
-    "theme": "Theme",
+    "id": "Identifiant",
+    "label": "Libellé",
+    "version": "Version ",
+    "referenceYear": "Millésime ",
+    "theme": "Thème ",
     "noValue": "Non renseigné"
   }
 }


### PR DESCRIPTION
Quelques typos sur l'écran des nomenclatures en français : 

<img width="302" height="126" alt="Screenshot 2026-07-07 at 10-25-00 Pogues" src="https://github.com/user-attachments/assets/ee61591a-ae77-47f9-b032-2bc6661fb07c" />

Il manque les accents sur "thème" et "millésime", et un espaces avant les ":".

---

J'ai corrigé les valeur pour identifiant/libellé au passage (mais je sais pas où ça sert, peut être qu'il faut ajouter "de la nomenclature").

### NB sur les espaces avant les ":"

En français on met un espace, en anglais c'est tout collé, j'ai triché en ajoutant un espace dans la valeur, peut-être gérer cet aspect de l'internationalisation ailleurs (par exp avec un utilitaire qq part dans le code)
